### PR TITLE
Add support for object types

### DIFF
--- a/attribute_type_marshal_unmarshal.go
+++ b/attribute_type_marshal_unmarshal.go
@@ -35,6 +35,19 @@ func (t SchemaAttributeType) MarshalJSON() ([]byte, error) {
 		buf.WriteRune(']')
 		return buf.Bytes(), nil
 
+	case objectAttributeType:
+		buf := &bytes.Buffer{}
+		atysJSON, err := json.Marshal(t.AttributeTypes())
+		if err != nil {
+			return nil, err
+		}
+		buf.WriteRune('[')
+		fmt.Fprintf(buf, "%q", objectAttributeTypeLabel)
+		buf.WriteRune(',')
+		buf.Write(atysJSON)
+		buf.WriteRune(']')
+		return buf.Bytes(), nil
+
 	default:
 		// should never happen
 		panic("unknown type implementation")
@@ -103,6 +116,19 @@ func (t *SchemaAttributeType) UnmarshalJSON(buf []byte) error {
 				SchemaAttributeTypeCollection{
 					kind:        collectionAttributeTypeKind(kind),
 					elementType: ety,
+				},
+			}
+
+		case objectAttributeTypeLabel:
+			var atys map[string]SchemaAttributeType
+			err = dec.Decode(&atys)
+			if err != nil {
+				return err
+			}
+
+			*t = SchemaAttributeType{
+				objectAttributeType{
+					attrTypes: atys,
 				},
 			}
 


### PR DESCRIPTION
This adds support for object types.

Object types are new HCL2 types that are shimmed from the current SDK
from schema fields that are generally list or set type, with a max
length of 1 and a resource element type.

Output of object types in the schema JSON is new as of beta2, hence
why it was not added earlier.