### PR TITLE
Go: use Go 1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/terraform-json
 
-go 1.12
+go 1.13
 
 require (
 	github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
Only necessary change is in go.mod, Circle is already on 1.13.