### PR TITLE
state: add new DeposedKey to state resources

### DIFF
--- a/state.go
+++ b/state.go
@@ -109,6 +109,10 @@ type StateResource struct {
 	// If true, the resource has been marked as tainted and will be
 	// re-created on the next update.
 	Tainted bool `json:"tainted,omitempty"`
+
+	// DeposedKey is set if the resource instance has been marked Deposed and
+	// will be destroyed on the next apply.
+	DeposedKey string `json:"deposed_key,omitempty"`
 }
 
 // StateOutput represents an output value in a common state


### PR DESCRIPTION
Deposed resources were missing from the `StateValues` output. This was fixed in https://github.com/hashicorp/terraform/pull/23027 (merged, but likely won't be released for at least two weeks).