### PR TITLE
Add depends_on support to module calls

### DIFF
--- a/config.go
+++ b/config.go
@@ -166,4 +166,8 @@ type ModuleCall struct {
 
 	// The version constraint for modules that come from the registry.
 	VersionConstraint string `json:"version_constraint,omitempty"`
+
+	// The explicit resource dependencies for the "depends_on" value.
+	// As it must be a slice of references, Expression is not used.
+	DependsOn []string `json:"depends_on,omitempty"`
 }


### PR DESCRIPTION
At this point in time it is not easy to add a test case as it is completely reliant on Terraform 0.13 being available. Some work needs to be done to support multiple terraform versions within the test scenarios.