### PR TITLE
Use docker mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 
 references:
   images:
-    go: &GOLANG_IMAGE circleci/golang:1.14
+    go: &GOLANG_IMAGE docker.mirror.hashicorp.services/circleci/golang:1.14
   cache:
     go-sum: &GO_SUM_CACHE_KEY go-sum-v1-{{ checksum "go.sum" }}
   environment: &ENVIRONMENT

--- a/testdata/Makefile
+++ b/testdata/Makefile
@@ -2,10 +2,10 @@ AWS_ENV_VARS=AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN AWS_REGIO
 TERRAFORM_DOCKER_CMD=docker run $(foreach var,$(AWS_ENV_VARS),--env $(var)) --rm --workdir "$$(pwd)" --volume "$$(pwd)":"$$(pwd)"
 
 TERRAFORM_012_VERSION=0.12.11
-TERRAFORM012=$(TERRAFORM_DOCKER_CMD) hashicorp/terraform:$(TERRAFORM_012_VERSION)
+TERRAFORM012=$(TERRAFORM_DOCKER_CMD) docker.mirror.hashicorp.services/hashicorp/terraform:$(TERRAFORM_012_VERSION)
 
 TERRAFORM_013_VERSION=0.13.1
-TERRAFORM013=$(TERRAFORM_DOCKER_CMD) hashicorp/terraform:$(TERRAFORM_013_VERSION)
+TERRAFORM013=$(TERRAFORM_DOCKER_CMD) docker.mirror.hashicorp.services/hashicorp/terraform:$(TERRAFORM_013_VERSION)
 
 FIXTURES ?= $(shell find * -maxdepth 0 -type d -not -name "013*")
 013FIXTURES ?= $(shell find * -maxdepth 0 -type d -name "013*")


### PR DESCRIPTION
Instead of using dockerhub (which will enforce rate limiting on anonymous image pulls starting Nov 1st), we're moving projects to our mirror at `docker.mirror.hashicorp.services`. We're updating CircleCI configs, docker compose, dockerfiles, relevant parts of Makefiles, and travis configs. Github actions are excluded, as Github is handling the issue on their end. LMK if you have any q's, otherwise feel free to approve and merge on your own! 