### PR TITLE
Fix SchemaDescriptionKindPlain value (plaintext -> plain)

### DIFF
--- a/schemas.go
+++ b/schemas.go
@@ -88,7 +88,7 @@ type SchemaDescriptionKind string
 
 const (
 	// SchemaDescriptionKindPlain indicates a string in plain text format.
-	SchemaDescriptionKindPlain SchemaDescriptionKind = "plaintext"
+	SchemaDescriptionKindPlain SchemaDescriptionKind = "plain"
 
 	// SchemaDescriptionKindMarkdown indicates a Markdown string and may need to be
 	// processed prior to presentation.


### PR DESCRIPTION
This has always been `plain`: https://github.com/hashicorp/terraform/blob/c258e8efbb3146a79f3e47ce934722580407036d/command/jsonprovider/attribute.go#L23, it was just unfortunately missed in the initial PR.

I have a workaround in place where I use this library:
https://github.com/hashicorp/terraform-schema/blob/0c9744a02c6568f0d157e48c24f281babe865de9/schema/schema_merge.go#L259-L262

and this patch would allow me to remove it.