### PR TITLE
Add version output

### DIFF
--- a/version.go
+++ b/version.go
@@ -1,0 +1,11 @@
+package tfjson
+
+// VersionOutput represents output from the version -json command
+// added in v0.13
+type VersionOutput struct {
+	Version            string            `json:"terraform_version"`
+	Revision           string            `json:"terraform_revision"`
+	Platform           string            `json:"platform,omitempty"`
+	ProviderSelections map[string]string `json:"provider_selections"`
+	Outdated           bool              `json:"terraform_outdated"`
+}

--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,66 @@
+package tfjson
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestVersionOutput_013(t *testing.T) {
+	errOutput := `{
+  "terraform_version": "0.13.5",
+  "terraform_revision": "",
+  "provider_selections": {
+    "registry.terraform.io/hashicorp/github": "2.9.2",
+    "registry.terraform.io/hashicorp/random": "3.0.0"
+  },
+  "terraform_outdated": true
+}`
+	var parsed VersionOutput
+	if err := json.Unmarshal([]byte(errOutput), &parsed); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := &VersionOutput{
+		Version: "0.13.5",
+		ProviderSelections: map[string]string{
+			"registry.terraform.io/hashicorp/github": "2.9.2",
+			"registry.terraform.io/hashicorp/random": "3.0.0",
+		},
+		Outdated: true,
+	}
+	if diff := cmp.Diff(expected, &parsed); diff != "" {
+		t.Fatalf("output mismatch: %s", diff)
+	}
+}
+
+func TestVersionOutput_015(t *testing.T) {
+	errOutput := `{
+  "terraform_version": "0.15.0-dev",
+  "terraform_revision": "ae025248cc0712bf53c675dc2fe77af4276dd5cc",
+  "platform": "darwin_amd64",
+  "provider_selections": {
+    "registry.terraform.io/hashicorp/github": "2.9.2",
+    "registry.terraform.io/hashicorp/random": "3.0.0"
+  },
+  "terraform_outdated": false
+}`
+	var parsed VersionOutput
+	if err := json.Unmarshal([]byte(errOutput), &parsed); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := &VersionOutput{
+		Version:  "0.15.0-dev",
+		Revision: "ae025248cc0712bf53c675dc2fe77af4276dd5cc",
+		Platform: "darwin_amd64",
+		ProviderSelections: map[string]string{
+			"registry.terraform.io/hashicorp/github": "2.9.2",
+			"registry.terraform.io/hashicorp/random": "3.0.0",
+		},
+	}
+	if diff := cmp.Diff(expected, &parsed); diff != "" {
+		t.Fatalf("output mismatch: %s", diff)
+	}
+}


### PR DESCRIPTION
This is likely to conflict with https://github.com/hashicorp/terraform-json/pull/23 - I can rebase the other one when either of these PRs are merged.

--- 

It is planned to parse the JSON output in `terraform-exec` at some point as per https://github.com/hashicorp/terraform-exec/issues/13 and this PR would therefore support these efforts.

The struct is practically copy&paste of the one used in core:

https://github.com/hashicorp/terraform/blob/ae025248cc0712bf53c675dc2fe77af4276dd5cc/command/version.go#L26-L32

I just added `omitempty` to `platform` since that was introduced in v0.15, although I don't expect anyone will actually use these structs for marshalling.