### PR TITLE
Use json.Number instead of float64 when parsing state.

### DIFF
--- a/state.go
+++ b/state.go
@@ -1,6 +1,7 @@
 package tfjson
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -46,7 +47,9 @@ func (s *State) UnmarshalJSON(b []byte) error {
 	type rawState State
 	var state rawState
 
-	err := json.Unmarshal(b, &state)
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.UseNumber()
+	err := dec.Decode(&state)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
State values can contain numbers that are larger than `float64` can
precisely represent. `json.Unmarshal` when unmarshaled into an
`interface{}` uses `float64` to represent numbers by default. To
properly retain precision for numbers, we need to use a custom
`json.Decoder` with the `UseNumber()` method called on it, which will
use `json.Number` (a `string` alias) to store the numbers, preserving
their precision.