### PR TITLE
Reflect v0.15 schema changes

### DIFF
--- a/schemas.go
+++ b/schemas.go
@@ -10,7 +10,7 @@ import (
 
 // ProviderSchemasFormatVersion is the version of the JSON provider
 // schema format that is supported by this package.
-const ProviderSchemasFormatVersion = "0.1"
+const ProviderSchemasFormatVersion = "0.2"
 
 // ProviderSchemas represents the schemas of all providers and
 // resources in use by the configuration.
@@ -38,8 +38,10 @@ func (p *ProviderSchemas) Validate() error {
 		return errors.New("unexpected provider schema data, format version is missing")
 	}
 
-	if ProviderSchemasFormatVersion != p.FormatVersion {
-		return fmt.Errorf("unsupported provider schema data format version: expected %q, got %q", PlanFormatVersion, p.FormatVersion)
+	oldVersion := "0.1"
+	if p.FormatVersion != ProviderSchemasFormatVersion && p.FormatVersion != oldVersion {
+		return fmt.Errorf("unsupported provider schema data format version: expected %q or %q, got %q",
+			PlanFormatVersion, oldVersion, p.FormatVersion)
 	}
 
 	return nil


### PR DESCRIPTION
This reflects a change introduced a while ago in https://github.com/hashicorp/terraform/pull/20949 and also changes introduced as part of https://github.com/hashicorp/terraform/pull/28055, https://github.com/hashicorp/terraform/pull/27699 and https://github.com/hashicorp/terraform/pull/27793

The mentioned PRs do _not_ change anything about the underlying _syntax_ that couldn't be already expressed using the `SchemaAttribute.AttributeType`, however these changes allow the SDK and providers to communicate some additional metadata that cannot be communicated via "pure" `cty.Type`, such as sensitivity, or description for each individual attribute.

These new features are not in use by the SDK nor the built-in `terraform` provider yet (AFAIK), but this allows us to support it when the time comes.

Closes #27