### PR TITLE
sanitize: allow for the sanitization of sensitive values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,7 @@ go 1.13
 require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/google/go-cmp v0.3.1
+	github.com/mitchellh/copystructure v1.2.0
+	github.com/sebdah/goldie v1.0.0
 	github.com/zclconf/go-cty v1.2.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,5 @@
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -8,6 +9,17 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
+github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
+github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
+github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
+github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sebdah/goldie v1.0.0 h1:9GNhIat69MSlz/ndaBg48vl9dF5fI+NBB6kfOxgfkMc=
+github.com/sebdah/goldie v1.0.0/go.mod h1:jXP4hmWywNEwZzhMuv2ccnqTSFpuq8iyQhtQdkkZBH4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/zclconf/go-cty v1.2.1 h1:vGMsygfmeCl4Xb6OA5U5XVAaQZ69FvoG7X2jUtQujb8=
 github.com/zclconf/go-cty v1.2.1/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=

--- a/sanitize/copy.go
+++ b/sanitize/copy.go
@@ -1,0 +1,74 @@
+package sanitize
+
+import (
+	"reflect"
+
+	tfjson "github.com/hashicorp/terraform-json"
+	"github.com/mitchellh/copystructure"
+)
+
+// copyStructureCopy is an internal function that wraps copystructure.Copy with
+// a shallow copier for unknown values.
+//
+// Performing the shallow copy of the unknown values is important
+// here, as unknown values are parsed in with the main terraform-json
+// package as singletons, and must continue to be comparable.
+func copyStructureCopy(v interface{}) (interface{}, error) {
+	c := &copystructure.Config{
+		ShallowCopiers: map[reflect.Type]struct{}{
+			reflect.TypeOf(tfjson.UnknownConstantValue): struct{}{},
+		},
+	}
+
+	return c.Copy(v)
+}
+
+// copyChange copies a Change value and returns the copy.
+func copyChange(old *tfjson.Change) (*tfjson.Change, error) {
+	c, err := copyStructureCopy(old)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.(*tfjson.Change), nil
+}
+
+// copyPlan copies a Plan value and returns the copy.
+func copyPlan(old *tfjson.Plan) (*tfjson.Plan, error) {
+	c, err := copyStructureCopy(old)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.(*tfjson.Plan), nil
+}
+
+// copyPlanVariable copies a PlanVariable value and returns the copy.
+func copyPlanVariable(old *tfjson.PlanVariable) (*tfjson.PlanVariable, error) {
+	c, err := copyStructureCopy(old)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.(*tfjson.PlanVariable), nil
+}
+
+// copyStateResource copies a StateResource value and returns the copy.
+func copyStateResource(old *tfjson.StateResource) (*tfjson.StateResource, error) {
+	c, err := copyStructureCopy(old)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.(*tfjson.StateResource), nil
+}
+
+// copyStateOutput copies a StateOutput value and returns the copy.
+func copyStateOutputs(old map[string]*tfjson.StateOutput) (map[string]*tfjson.StateOutput, error) {
+	c, err := copystructure.Copy(old)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.(map[string]*tfjson.StateOutput), nil
+}

--- a/sanitize/copy_test.go
+++ b/sanitize/copy_test.go
@@ -1,0 +1,19 @@
+package sanitize
+
+import (
+	"testing"
+
+	tfjson "github.com/hashicorp/terraform-json"
+)
+
+func TestCopyStructureCopy(t *testing.T) {
+	in := tfjson.UnknownConstantValue
+	out, err := copyStructureCopy(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if in != out {
+		t.Fatal("did not shallow copy")
+	}
+}

--- a/sanitize/sanitize_change.go
+++ b/sanitize/sanitize_change.go
@@ -1,0 +1,53 @@
+package sanitize
+
+import (
+	tfjson "github.com/hashicorp/terraform-json"
+)
+
+// SanitizeChange traverses a Change and replaces all values at
+// the particular locations marked by BeforeSensitive AfterSensitive
+// with the value supplied as replaceWith.
+//
+// A new change is issued.
+func SanitizeChange(old *tfjson.Change, replaceWith interface{}) (*tfjson.Change, error) {
+	result, err := copyChange(old)
+	if err != nil {
+		return nil, err
+	}
+
+	result.Before = sanitizeChangeValue(result.Before, result.BeforeSensitive, replaceWith)
+	result.After = sanitizeChangeValue(result.After, result.AfterSensitive, replaceWith)
+
+	return result, nil
+}
+
+func sanitizeChangeValue(old, sensitive, replaceWith interface{}) interface{} {
+	// Only expect deep types that we would normally see in JSON, so
+	// arrays and objects.
+	switch x := old.(type) {
+	case []interface{}:
+		if filterSlice, ok := sensitive.([]interface{}); ok {
+			for i := range filterSlice {
+				if i >= len(x) {
+					break
+				}
+
+				x[i] = sanitizeChangeValue(x[i], filterSlice[i], replaceWith)
+			}
+		}
+	case map[string]interface{}:
+		if filterMap, ok := sensitive.(map[string]interface{}); ok {
+			for filterKey := range filterMap {
+				if value, ok := x[filterKey]; ok {
+					x[filterKey] = sanitizeChangeValue(value, filterMap[filterKey], replaceWith)
+				}
+			}
+		}
+	}
+
+	if shouldFilter, ok := sensitive.(bool); ok && shouldFilter {
+		return replaceWith
+	}
+
+	return old
+}

--- a/sanitize/sanitize_change_test.go
+++ b/sanitize/sanitize_change_test.go
@@ -1,0 +1,142 @@
+package sanitize
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	tfjson "github.com/hashicorp/terraform-json"
+)
+
+type testChangeCase struct {
+	name     string
+	old      *tfjson.Change
+	expected *tfjson.Change
+}
+
+func changeCases() []testChangeCase {
+	return []testChangeCase{
+		{
+			name: "basic",
+			old: &tfjson.Change{
+				Before: map[string]interface{}{
+					"foo": map[string]interface{}{"a": "foo"},
+					"bar": map[string]interface{}{"a": "foo"},
+					"baz": map[string]interface{}{"a": "foo"},
+					"qux": map[string]interface{}{
+						"a": map[string]interface{}{
+							"b": "foo",
+						},
+						"c": "bar",
+					},
+					"quxx": map[string]interface{}{
+						"a": map[string]interface{}{
+							"b": "foo",
+						},
+						"c": "bar",
+					},
+				},
+				After: map[string]interface{}{
+					"one":   map[string]interface{}{"x": "one"},
+					"two":   map[string]interface{}{"x": "one"},
+					"three": map[string]interface{}{"x": "one"},
+					"four": map[string]interface{}{
+						"x": map[string]interface{}{
+							"y": "one",
+						},
+						"z": "two",
+					},
+					"five": map[string]interface{}{
+						"x": map[string]interface{}{
+							"y": "one",
+						},
+						"z": "two",
+					},
+				},
+				BeforeSensitive: map[string]interface{}{
+					"foo":  map[string]interface{}{},
+					"bar":  true,
+					"baz":  map[string]interface{}{"a": true},
+					"qux":  map[string]interface{}{},
+					"quxx": map[string]interface{}{"c": true},
+				},
+				AfterSensitive: map[string]interface{}{
+					"one":   map[string]interface{}{},
+					"two":   true,
+					"three": map[string]interface{}{"x": true},
+					"four":  map[string]interface{}{},
+					"five":  map[string]interface{}{"z": true},
+				},
+			},
+			expected: &tfjson.Change{
+				Before: map[string]interface{}{
+					"foo": map[string]interface{}{"a": "foo"},
+					"bar": DefaultSensitiveValue,
+					"baz": map[string]interface{}{"a": DefaultSensitiveValue},
+					"qux": map[string]interface{}{
+						"a": map[string]interface{}{
+							"b": "foo",
+						},
+						"c": "bar",
+					},
+					"quxx": map[string]interface{}{
+						"a": map[string]interface{}{
+							"b": "foo",
+						},
+						"c": DefaultSensitiveValue,
+					},
+				},
+				After: map[string]interface{}{
+					"one":   map[string]interface{}{"x": "one"},
+					"two":   DefaultSensitiveValue,
+					"three": map[string]interface{}{"x": DefaultSensitiveValue},
+					"four": map[string]interface{}{
+						"x": map[string]interface{}{
+							"y": "one",
+						},
+						"z": "two",
+					},
+					"five": map[string]interface{}{
+						"x": map[string]interface{}{
+							"y": "one",
+						},
+						"z": DefaultSensitiveValue,
+					},
+				},
+				BeforeSensitive: map[string]interface{}{
+					"foo":  map[string]interface{}{},
+					"bar":  true,
+					"baz":  map[string]interface{}{"a": true},
+					"qux":  map[string]interface{}{},
+					"quxx": map[string]interface{}{"c": true},
+				},
+				AfterSensitive: map[string]interface{}{
+					"one":   map[string]interface{}{},
+					"two":   true,
+					"three": map[string]interface{}{"x": true},
+					"four":  map[string]interface{}{},
+					"five":  map[string]interface{}{"z": true},
+				},
+			},
+		},
+	}
+}
+
+func TestSanitizeChange(t *testing.T) {
+	for i, tc := range changeCases() {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := SanitizeChange(tc.old, DefaultSensitiveValue)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expected, actual); diff != "" {
+				t.Errorf("SanitizeChange() mismatch (-expected +actual):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(changeCases()[i].old, tc.old); diff != "" {
+				t.Errorf("SanitizeChange() altered original (-expected +actual):\n%s", diff)
+			}
+		})
+	}
+}

--- a/sanitize/sanitize_plan.go
+++ b/sanitize/sanitize_plan.go
@@ -1,0 +1,114 @@
+package sanitize
+
+import (
+	"errors"
+
+	tfjson "github.com/hashicorp/terraform-json"
+)
+
+const DefaultSensitiveValue = "REDACTED_SENSITIVE"
+
+var NilPlanError = errors.New("nil plan supplied")
+
+// SanitizePlan sanitizes the entirety of a Plan, replacing sensitive
+// values with the default value in DefaultSensitiveValue.
+//
+// See SanitizePlanWithValue for full detail on the where replacement
+// takes place.
+func SanitizePlan(old *tfjson.Plan) (*tfjson.Plan, error) {
+	return SanitizePlanWithValue(old, DefaultSensitiveValue)
+}
+
+// SanitizePlanWithValue sanitizes the entirety of a Plan to the best
+// of its ability, depending on the provided metadata on sensitive
+// values. These are found in:
+//
+// * ResourceChanges: Sanitized based on BeforeSensitive and
+// AfterSensitive fields.
+//
+// * Variables: Based on variable config data found in the root
+// module of the Config.
+//
+// * PlannedValues: Sanitized based on the values found in
+// AfterSensitive in ResourceChanges. Outputs are sanitized
+// according to the appropriate sensitivity flags provided for the
+// output.
+//
+// * PriorState: Sanitized based on the values found in
+// BeforeSensitive in ResourceChanges. Outputs are sanitized according
+// to the appropriate sensitivity flags provided for the output.
+//
+// * OutputChanges: Sanitized based on the values found in
+// BeforeSensitive and AfterSensitive. This generally means that
+// any sensitive output will have OutputChange fully obfuscated as
+// the BeforeSensitive and AfterSensitive in outputs are opaquely the
+// same.
+//
+// Sensitive values are replaced with the value supplied with
+// replaceWith. A copy of the Plan is returned.
+func SanitizePlanWithValue(old *tfjson.Plan, replaceWith interface{}) (*tfjson.Plan, error) {
+	if old == nil {
+		return nil, NilPlanError
+	}
+
+	result, err := copyPlan(old)
+	if err != nil {
+		return nil, err
+	}
+
+	// Sanitize ResourceChanges
+	for i := range result.ResourceChanges {
+		result.ResourceChanges[i].Change, err = SanitizeChange(result.ResourceChanges[i].Change, replaceWith)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Sanitize Variables
+	result.Variables, err = SanitizePlanVariables(result.Variables, result.Config.RootModule.Variables, replaceWith)
+	if err != nil {
+		return nil, err
+	}
+
+	// Sanitize PlannedValues
+	result.PlannedValues.RootModule, err = SanitizeStateModule(
+		result.PlannedValues.RootModule,
+		result.ResourceChanges,
+		SanitizeStateModuleChangeModeAfter,
+		replaceWith)
+	if err != nil {
+		return nil, err
+	}
+
+	result.PlannedValues.Outputs, err = SanitizeStateOutputs(result.PlannedValues.Outputs, replaceWith)
+	if err != nil {
+		return nil, err
+	}
+
+	// Sanitize PriorState
+	if result.PriorState != nil {
+		result.PriorState.Values.RootModule, err = SanitizeStateModule(
+			result.PriorState.Values.RootModule,
+			result.ResourceChanges,
+			SanitizeStateModuleChangeModeBefore,
+			replaceWith)
+		if err != nil {
+			return nil, err
+		}
+
+		result.PriorState.Values.Outputs, err = SanitizeStateOutputs(result.PriorState.Values.Outputs, replaceWith)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Sanitize OutputChanges
+	for k := range result.OutputChanges {
+		result.OutputChanges[k], err = SanitizeChange(result.OutputChanges[k], replaceWith)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return result, nil
+}

--- a/sanitize/sanitize_plan_test.go
+++ b/sanitize/sanitize_plan_test.go
@@ -1,0 +1,86 @@
+package sanitize
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tfjson "github.com/hashicorp/terraform-json"
+	"github.com/sebdah/goldie"
+)
+
+const testDataDir = "testdata"
+
+func TestSanitizePlanGolden(t *testing.T) {
+	cases, err := goldenCases()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name(), testSanitizePlanGoldenEntry(tc))
+	}
+}
+
+func testSanitizePlanGoldenEntry(c testGoldenCase) func(t *testing.T) {
+	return func(t *testing.T) {
+		p := new(tfjson.Plan)
+		err := json.Unmarshal(c.InputData, p)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		p, err = SanitizePlan(p)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		goldie.AssertJson(t, c.Name(), p)
+	}
+}
+
+type testGoldenCase struct {
+	FileName  string
+	InputData []byte
+}
+
+func (c *testGoldenCase) Name() string {
+	return strings.TrimSuffix(c.FileName, filepath.Ext(c.FileName))
+}
+
+func goldenCases() ([]testGoldenCase, error) {
+	d, err := os.Open(testDataDir)
+	if err != nil {
+		return nil, err
+	}
+
+	entries, err := d.ReadDir(0)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]testGoldenCase, 0)
+	for _, e := range entries {
+		if !e.Type().IsRegular() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+
+		data, err := os.ReadFile(filepath.Join(testDataDir, e.Name()))
+		if err != nil {
+			return nil, err
+		}
+
+		result = append(result, testGoldenCase{
+			FileName:  e.Name(),
+			InputData: data,
+		})
+	}
+
+	return result, err
+}
+
+func init() {
+	goldie.FixtureDir = testDataDir
+}

--- a/sanitize/sanitize_plan_variables.go
+++ b/sanitize/sanitize_plan_variables.go
@@ -1,0 +1,46 @@
+package sanitize
+
+import (
+	tfjson "github.com/hashicorp/terraform-json"
+)
+
+// SanitizePlanVariables traverses a map of PlanVariable and replaces
+// any sensitive values with the value supplied in replaceWith.
+// configs should be the map of ConfigVariables from the root module
+// (so Plan.Config.RootModule.Variables).
+//
+// A new copy of the PlanVariable map is returned.
+func SanitizePlanVariables(
+	old map[string]*tfjson.PlanVariable,
+	configs map[string]*tfjson.ConfigVariable,
+	replaceWith interface{},
+) (map[string]*tfjson.PlanVariable, error) {
+	result := make(map[string]*tfjson.PlanVariable, len(old))
+	for k := range old {
+		v, err := sanitizeVariable(old[k], configs[k], replaceWith)
+		if err != nil {
+			return nil, err
+		}
+
+		result[k] = v
+	}
+
+	return result, nil
+}
+
+func sanitizeVariable(
+	old *tfjson.PlanVariable,
+	config *tfjson.ConfigVariable,
+	replaceWith interface{},
+) (*tfjson.PlanVariable, error) {
+	result, err := copyPlanVariable(old)
+	if err != nil {
+		return nil, err
+	}
+
+	if config != nil && config.Sensitive {
+		result.Value = replaceWith
+	}
+
+	return result, nil
+}

--- a/sanitize/sanitize_plan_variables_test.go
+++ b/sanitize/sanitize_plan_variables_test.go
@@ -1,0 +1,67 @@
+package sanitize
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	tfjson "github.com/hashicorp/terraform-json"
+)
+
+type testVariablesCase struct {
+	name     string
+	old      map[string]*tfjson.PlanVariable
+	configs  map[string]*tfjson.ConfigVariable
+	expected map[string]*tfjson.PlanVariable
+}
+
+func variablesCases() []testVariablesCase {
+	return []testVariablesCase{
+		{
+			name: "basic",
+			old: map[string]*tfjson.PlanVariable{
+				"foo": &tfjson.PlanVariable{
+					Value: "test-foo",
+				},
+				"bar": &tfjson.PlanVariable{
+					Value: "test-bar",
+				},
+			},
+			configs: map[string]*tfjson.ConfigVariable{
+				"foo": &tfjson.ConfigVariable{
+					Sensitive: false,
+				},
+				"bar": &tfjson.ConfigVariable{
+					Sensitive: true,
+				},
+			},
+			expected: map[string]*tfjson.PlanVariable{
+				"foo": &tfjson.PlanVariable{
+					Value: "test-foo",
+				},
+				"bar": &tfjson.PlanVariable{
+					Value: DefaultSensitiveValue,
+				},
+			},
+		},
+	}
+}
+
+func TestSanitizePlanVariables(t *testing.T) {
+	for i, tc := range variablesCases() {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := SanitizePlanVariables(tc.old, tc.configs, DefaultSensitiveValue)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expected, actual); diff != "" {
+				t.Errorf("SanitizePlanVariables() mismatch (-expected +actual):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(variablesCases()[i].old, tc.old); diff != "" {
+				t.Errorf("SanitizePlanVariables() altered original (-expected +actual):\n%s", diff)
+			}
+		})
+	}
+}

--- a/sanitize/sanitize_state.go
+++ b/sanitize/sanitize_state.go
@@ -1,0 +1,131 @@
+package sanitize
+
+import (
+	"fmt"
+
+	tfjson "github.com/hashicorp/terraform-json"
+)
+
+type SanitizeStateModuleChangeMode string
+
+const (
+	SanitizeStateModuleChangeModeBefore SanitizeStateModuleChangeMode = "before_sensitive"
+	SanitizeStateModuleChangeModeAfter  SanitizeStateModuleChangeMode = "after_sensitive"
+)
+
+// SanitizeStateModule traverses a StateModule, consulting the
+// supplied ResourceChange set for resources to determine whether or
+// not particular values should be obfuscated.
+//
+// Use mode to supply the SanitizeStateModuleChangeMode that
+// represents what sensitive field should be consulted to determine
+// whether or not the value should be obfuscated:
+//
+// * SanitizeStateModuleChangeModeBefore for before_sensitive
+// * SanitizeStateModuleChangeModeAfter for after_sensitive
+//
+// Sensitive values are replaced with the supplied replaceWith value.
+// A new state module tree is issued.
+func SanitizeStateModule(
+	old *tfjson.StateModule,
+	resourceChanges []*tfjson.ResourceChange,
+	mode SanitizeStateModuleChangeMode,
+	replaceWith interface{},
+) (*tfjson.StateModule, error) {
+	result := &tfjson.StateModule{
+		Resources:    make([]*tfjson.StateResource, len(old.Resources)),
+		Address:      old.Address,
+		ChildModules: make([]*tfjson.StateModule, len(old.ChildModules)),
+	}
+
+	for i := range old.Resources {
+		var err error
+		result.Resources[i], err = sanitizeStateResource(
+			old.Resources[i],
+			findResourceChange(resourceChanges, old.Resources[i].Address),
+			mode,
+			replaceWith,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for i := range old.ChildModules {
+		var err error
+		result.ChildModules[i], err = SanitizeStateModule(
+			old.ChildModules[i],
+			resourceChanges,
+			mode,
+			replaceWith,
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return result, nil
+}
+
+func sanitizeStateResource(
+	old *tfjson.StateResource,
+	rc *tfjson.ResourceChange,
+	mode SanitizeStateModuleChangeMode,
+	replaceWith interface{},
+) (*tfjson.StateResource, error) {
+	result, err := copyStateResource(old)
+	if err != nil {
+		return nil, err
+	}
+
+	if rc == nil {
+		return result, nil
+	}
+
+	var sensitive interface{}
+	switch mode {
+	case SanitizeStateModuleChangeModeBefore:
+		sensitive = rc.Change.BeforeSensitive
+
+	case SanitizeStateModuleChangeModeAfter:
+		sensitive = rc.Change.AfterSensitive
+
+	default:
+		panic(fmt.Sprintf("invalid change mode %q", mode))
+	}
+
+	// We can re-use sanitizeChangeValue here to do the sanitization.
+	result.AttributeValues = sanitizeChangeValue(result.AttributeValues, sensitive, replaceWith).(map[string]interface{})
+	return result, nil
+}
+
+func findResourceChange(resourceChanges []*tfjson.ResourceChange, addr string) *tfjson.ResourceChange {
+	// Linear search here, unfortunately :P
+	for _, rc := range resourceChanges {
+		if rc.Address == addr {
+			return rc
+		}
+	}
+
+	return nil
+}
+
+// SanitizeStateOutputs scans the supplied map of StateOutputs and
+// replaces any values of outputs marked as Sensitive with the value
+// supplied in replaceWith.
+//
+// A new copy of StateOutputs is returned.
+func SanitizeStateOutputs(old map[string]*tfjson.StateOutput, replaceWith interface{}) (map[string]*tfjson.StateOutput, error) {
+	result, err := copyStateOutputs(old)
+	if err != nil {
+		return nil, err
+	}
+
+	for k := range result {
+		if result[k].Sensitive {
+			result[k].Value = replaceWith
+		}
+	}
+
+	return result, nil
+}

--- a/sanitize/sanitize_state_test.go
+++ b/sanitize/sanitize_state_test.go
@@ -1,0 +1,257 @@
+package sanitize
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	tfjson "github.com/hashicorp/terraform-json"
+)
+
+type testStateCase struct {
+	name            string
+	old             *tfjson.StateModule
+	resourceChanges []*tfjson.ResourceChange
+	mode            SanitizeStateModuleChangeMode
+	expected        *tfjson.StateModule
+}
+
+func stateCases() []testStateCase {
+	return []testStateCase{
+		{
+			name: "before",
+			old: &tfjson.StateModule{
+				Resources: []*tfjson.StateResource{
+					{
+						Address: "null_resource.foo",
+						AttributeValues: map[string]interface{}{
+							"foo": "bar",
+							"baz": "qux",
+						},
+					},
+				},
+				Address: "",
+				ChildModules: []*tfjson.StateModule{
+					&tfjson.StateModule{
+						Resources: []*tfjson.StateResource{
+							{
+								Address: "module.foo.null_resource.bar",
+								AttributeValues: map[string]interface{}{
+									"a": "b",
+									"c": "d",
+								},
+							},
+						},
+						Address:      "module.foo",
+						ChildModules: []*tfjson.StateModule{},
+					},
+				},
+			},
+			resourceChanges: []*tfjson.ResourceChange{
+				{
+					Address: "null_resource.foo",
+					Change: &tfjson.Change{
+						BeforeSensitive: map[string]interface{}{
+							"baz": true,
+						},
+						AfterSensitive: map[string]interface{}{
+							"foo": true,
+						},
+					},
+				},
+				{
+					Address: "module.foo.null_resource.bar",
+					Change: &tfjson.Change{
+						BeforeSensitive: map[string]interface{}{
+							"a": true,
+						},
+						AfterSensitive: map[string]interface{}{
+							"c": true,
+						},
+					},
+				},
+			},
+			mode: SanitizeStateModuleChangeModeBefore,
+			expected: &tfjson.StateModule{
+				Resources: []*tfjson.StateResource{
+					{
+						Address: "null_resource.foo",
+						AttributeValues: map[string]interface{}{
+							"foo": "bar",
+							"baz": DefaultSensitiveValue,
+						},
+					},
+				},
+				Address: "",
+				ChildModules: []*tfjson.StateModule{
+					&tfjson.StateModule{
+						Resources: []*tfjson.StateResource{
+							{
+								Address: "module.foo.null_resource.bar",
+								AttributeValues: map[string]interface{}{
+									"a": DefaultSensitiveValue,
+									"c": "d",
+								},
+							},
+						},
+						Address:      "module.foo",
+						ChildModules: []*tfjson.StateModule{},
+					},
+				},
+			},
+		},
+		{
+			name: "after",
+			old: &tfjson.StateModule{
+				Resources: []*tfjson.StateResource{
+					{
+						Address: "null_resource.foo",
+						AttributeValues: map[string]interface{}{
+							"foo": "bar",
+							"baz": "qux",
+						},
+					},
+				},
+				Address: "",
+				ChildModules: []*tfjson.StateModule{
+					&tfjson.StateModule{
+						Resources: []*tfjson.StateResource{
+							{
+								Address: "module.foo.null_resource.bar",
+								AttributeValues: map[string]interface{}{
+									"a": "b",
+									"c": "d",
+								},
+							},
+						},
+						Address:      "module.foo",
+						ChildModules: []*tfjson.StateModule{},
+					},
+				},
+			},
+			resourceChanges: []*tfjson.ResourceChange{
+				{
+					Address: "null_resource.foo",
+					Change: &tfjson.Change{
+						BeforeSensitive: map[string]interface{}{
+							"baz": true,
+						},
+						AfterSensitive: map[string]interface{}{
+							"foo": true,
+						},
+					},
+				},
+				{
+					Address: "module.foo.null_resource.bar",
+					Change: &tfjson.Change{
+						BeforeSensitive: map[string]interface{}{
+							"a": true,
+						},
+						AfterSensitive: map[string]interface{}{
+							"c": true,
+						},
+					},
+				},
+			},
+			mode: SanitizeStateModuleChangeModeAfter,
+			expected: &tfjson.StateModule{
+				Resources: []*tfjson.StateResource{
+					{
+						Address: "null_resource.foo",
+						AttributeValues: map[string]interface{}{
+							"foo": DefaultSensitiveValue,
+							"baz": "qux",
+						},
+					},
+				},
+				Address: "",
+				ChildModules: []*tfjson.StateModule{
+					&tfjson.StateModule{
+						Resources: []*tfjson.StateResource{
+							{
+								Address: "module.foo.null_resource.bar",
+								AttributeValues: map[string]interface{}{
+									"a": "b",
+									"c": DefaultSensitiveValue,
+								},
+							},
+						},
+						Address:      "module.foo",
+						ChildModules: []*tfjson.StateModule{},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestSanitizeStateModule(t *testing.T) {
+	for i, tc := range stateCases() {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := SanitizeStateModule(tc.old, tc.resourceChanges, tc.mode, DefaultSensitiveValue)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expected, actual); diff != "" {
+				t.Errorf("SanitizeStateModule() mismatch (-expected +actual):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(stateCases()[i].old, tc.old); diff != "" {
+				t.Errorf("SanitizeStateModule() altered original (-expected +actual):\n%s", diff)
+			}
+		})
+	}
+}
+
+type testOutputCase struct {
+	name     string
+	old      map[string]*tfjson.StateOutput
+	expected map[string]*tfjson.StateOutput
+}
+
+func outputCases() []testOutputCase {
+	return []testOutputCase{
+		{
+			name: "basic",
+			old: map[string]*tfjson.StateOutput{
+				"foo": {
+					Value: "bar",
+				},
+				"a": {
+					Value:     "b",
+					Sensitive: true,
+				},
+			},
+			expected: map[string]*tfjson.StateOutput{
+				"foo": {
+					Value: "bar",
+				},
+				"a": {
+					Value:     DefaultSensitiveValue,
+					Sensitive: true,
+				},
+			},
+		},
+	}
+}
+
+func TestSanitizeStateOutputs(t *testing.T) {
+	for i, tc := range outputCases() {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := SanitizeStateOutputs(tc.old, DefaultSensitiveValue)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expected, actual); diff != "" {
+				t.Errorf("SanitizeStateOutputs() mismatch (-expected +actual):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(outputCases()[i].old, tc.old); diff != "" {
+				t.Errorf("SanitizeStateOutputs() altered original (-expected +actual):\n%s", diff)
+			}
+		})
+	}
+}

--- a/sanitize/testdata/basic.golden
+++ b/sanitize/testdata/basic.golden
@@ -1,0 +1,371 @@
+{
+  "format_version": "0.1",
+  "terraform_version": "0.15.1",
+  "variables": {
+    "foo": {
+      "value": "REDACTED_SENSITIVE"
+    },
+    "toggle_sensitive": {
+      "value": true
+    }
+  },
+  "planned_values": {
+    "outputs": {
+      "secret": {
+        "sensitive": true,
+        "value": "REDACTED_SENSITIVE"
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "null_resource.bar",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "bar",
+          "provider_name": "registry.terraform.io/hashicorp/null",
+          "schema_version": 0,
+          "values": {
+            "id": "4356817825751333663",
+            "triggers": "REDACTED_SENSITIVE"
+          }
+        },
+        {
+          "address": "null_resource.baz",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "baz",
+          "provider_name": "registry.terraform.io/hashicorp/null",
+          "schema_version": 0,
+          "values": {
+            "id": "2737458537890894185",
+            "triggers": {
+              "foo": "REDACTED_SENSITIVE"
+            }
+          }
+        },
+        {
+          "address": "null_resource.foo",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "foo",
+          "provider_name": "registry.terraform.io/hashicorp/null",
+          "schema_version": 0,
+          "values": {
+            "id": "7483449866618536328",
+            "triggers": {
+              "bar": "REDACTED_SENSITIVE",
+              "foo": "one"
+            }
+          }
+        },
+        {
+          "address": "null_resource.qux",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "qux",
+          "provider_name": "registry.terraform.io/hashicorp/null",
+          "schema_version": 0,
+          "values": {
+            "id": "389458145002419915",
+            "triggers": {
+              "foo": "REDACTED_SENSITIVE"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "null_resource.bar",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "bar",
+      "provider_name": "registry.terraform.io/hashicorp/null",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "id": "4356817825751333663",
+          "triggers": "REDACTED_SENSITIVE"
+        },
+        "after": {
+          "id": "4356817825751333663",
+          "triggers": "REDACTED_SENSITIVE"
+        },
+        "after_unknown": {},
+        "before_sensitive": {
+          "triggers": true
+        },
+        "after_sensitive": {
+          "triggers": true
+        }
+      }
+    },
+    {
+      "address": "null_resource.baz",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "baz",
+      "provider_name": "registry.terraform.io/hashicorp/null",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "id": "2737458537890894185",
+          "triggers": {
+            "foo": "REDACTED_SENSITIVE"
+          }
+        },
+        "after": {
+          "id": "2737458537890894185",
+          "triggers": {
+            "foo": "REDACTED_SENSITIVE"
+          }
+        },
+        "after_unknown": {},
+        "before_sensitive": {
+          "triggers": {
+            "foo": true
+          }
+        },
+        "after_sensitive": {
+          "triggers": {
+            "foo": true
+          }
+        }
+      }
+    },
+    {
+      "address": "null_resource.foo",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "foo",
+      "provider_name": "registry.terraform.io/hashicorp/null",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "id": "7483449866618536328",
+          "triggers": {
+            "bar": "REDACTED_SENSITIVE",
+            "foo": "one"
+          }
+        },
+        "after": {
+          "id": "7483449866618536328",
+          "triggers": {
+            "bar": "REDACTED_SENSITIVE",
+            "foo": "one"
+          }
+        },
+        "after_unknown": {},
+        "before_sensitive": {
+          "triggers": {
+            "bar": true
+          }
+        },
+        "after_sensitive": {
+          "triggers": {
+            "bar": true
+          }
+        }
+      }
+    },
+    {
+      "address": "null_resource.qux",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "qux",
+      "provider_name": "registry.terraform.io/hashicorp/null",
+      "change": {
+        "actions": [
+          "update"
+        ],
+        "before": {
+          "id": "389458145002419915",
+          "triggers": {
+            "foo": "bar"
+          }
+        },
+        "after": {
+          "id": "389458145002419915",
+          "triggers": {
+            "foo": "REDACTED_SENSITIVE"
+          }
+        },
+        "after_unknown": {},
+        "before_sensitive": {
+          "triggers": {}
+        },
+        "after_sensitive": {
+          "triggers": {
+            "foo": true
+          }
+        }
+      }
+    }
+  ],
+  "output_changes": {
+    "secret": {
+      "actions": [
+        "no-op"
+      ],
+      "before": "REDACTED_SENSITIVE",
+      "after": "REDACTED_SENSITIVE",
+      "after_unknown": false,
+      "before_sensitive": true,
+      "after_sensitive": true
+    }
+  },
+  "prior_state": {
+    "format_version": "0.1",
+    "terraform_version": "0.15.1",
+    "values": {
+      "outputs": {
+        "secret": {
+          "sensitive": true,
+          "value": "REDACTED_SENSITIVE"
+        }
+      },
+      "root_module": {
+        "resources": [
+          {
+            "address": "null_resource.bar",
+            "mode": "managed",
+            "type": "null_resource",
+            "name": "bar",
+            "provider_name": "registry.terraform.io/hashicorp/null",
+            "schema_version": 0,
+            "values": {
+              "id": "4356817825751333663",
+              "triggers": "REDACTED_SENSITIVE"
+            }
+          },
+          {
+            "address": "null_resource.baz",
+            "mode": "managed",
+            "type": "null_resource",
+            "name": "baz",
+            "provider_name": "registry.terraform.io/hashicorp/null",
+            "schema_version": 0,
+            "values": {
+              "id": "2737458537890894185",
+              "triggers": {
+                "foo": "REDACTED_SENSITIVE"
+              }
+            }
+          },
+          {
+            "address": "null_resource.foo",
+            "mode": "managed",
+            "type": "null_resource",
+            "name": "foo",
+            "provider_name": "registry.terraform.io/hashicorp/null",
+            "schema_version": 0,
+            "values": {
+              "id": "7483449866618536328",
+              "triggers": {
+                "bar": "REDACTED_SENSITIVE",
+                "foo": "one"
+              }
+            }
+          },
+          {
+            "address": "null_resource.qux",
+            "mode": "managed",
+            "type": "null_resource",
+            "name": "qux",
+            "provider_name": "registry.terraform.io/hashicorp/null",
+            "schema_version": 0,
+            "values": {
+              "id": "389458145002419915",
+              "triggers": {
+                "foo": "bar"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "configuration": {
+    "root_module": {
+      "outputs": {
+        "secret": {
+          "sensitive": true,
+          "expression": {
+            "references": [
+              "null_resource.foo"
+            ]
+          }
+        }
+      },
+      "resources": [
+        {
+          "address": "null_resource.bar",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "bar",
+          "provider_config_key": "null",
+          "expressions": {
+            "triggers": {}
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "null_resource.baz",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "baz",
+          "provider_config_key": "null",
+          "expressions": {
+            "triggers": {
+              "references": [
+                "var.foo"
+              ]
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "null_resource.foo",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "foo",
+          "provider_config_key": "null",
+          "expressions": {
+            "triggers": {}
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "null_resource.qux",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "qux",
+          "provider_config_key": "null",
+          "expressions": {
+            "triggers": {
+              "references": [
+                "var.toggle_sensitive"
+              ]
+            }
+          },
+          "schema_version": 0
+        }
+      ],
+      "variables": {
+        "foo": {
+          "default": "bar",
+          "sensitive": true
+        },
+        "toggle_sensitive": {}
+      }
+    }
+  }
+}

--- a/sanitize/testdata/basic.json
+++ b/sanitize/testdata/basic.json
@@ -1,0 +1,383 @@
+{
+  "format_version": "0.1",
+  "terraform_version": "0.15.1",
+  "variables": {
+    "foo": {
+      "value": "bar"
+    },
+    "toggle_sensitive": {
+      "value": true
+    }
+  },
+  "planned_values": {
+    "outputs": {
+      "secret": {
+        "sensitive": true,
+        "value": "7483449866618536328"
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "null_resource.bar",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "bar",
+          "provider_name": "registry.terraform.io/hashicorp/null",
+          "schema_version": 0,
+          "values": {
+            "id": "4356817825751333663",
+            "triggers": {
+              "bar": "two",
+              "foo": "one"
+            }
+          }
+        },
+        {
+          "address": "null_resource.baz",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "baz",
+          "provider_name": "registry.terraform.io/hashicorp/null",
+          "schema_version": 0,
+          "values": {
+            "id": "2737458537890894185",
+            "triggers": {
+              "foo": "bar"
+            }
+          }
+        },
+        {
+          "address": "null_resource.foo",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "foo",
+          "provider_name": "registry.terraform.io/hashicorp/null",
+          "schema_version": 0,
+          "values": {
+            "id": "7483449866618536328",
+            "triggers": {
+              "bar": "two",
+              "foo": "one"
+            }
+          }
+        },
+        {
+          "address": "null_resource.qux",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "qux",
+          "provider_name": "registry.terraform.io/hashicorp/null",
+          "schema_version": 0,
+          "values": {
+            "id": "389458145002419915",
+            "triggers": {
+              "foo": "bar"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "null_resource.bar",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "bar",
+      "provider_name": "registry.terraform.io/hashicorp/null",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "id": "4356817825751333663",
+          "triggers": {
+            "bar": "two",
+            "foo": "one"
+          }
+        },
+        "after": {
+          "id": "4356817825751333663",
+          "triggers": {
+            "bar": "two",
+            "foo": "one"
+          }
+        },
+        "after_unknown": {},
+        "before_sensitive": {
+          "triggers": true
+        },
+        "after_sensitive": {
+          "triggers": true
+        }
+      }
+    },
+    {
+      "address": "null_resource.baz",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "baz",
+      "provider_name": "registry.terraform.io/hashicorp/null",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "id": "2737458537890894185",
+          "triggers": {
+            "foo": "bar"
+          }
+        },
+        "after": {
+          "id": "2737458537890894185",
+          "triggers": {
+            "foo": "bar"
+          }
+        },
+        "after_unknown": {},
+        "before_sensitive": {
+          "triggers": {
+            "foo": true
+          }
+        },
+        "after_sensitive": {
+          "triggers": {
+            "foo": true
+          }
+        }
+      }
+    },
+    {
+      "address": "null_resource.foo",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "foo",
+      "provider_name": "registry.terraform.io/hashicorp/null",
+      "change": {
+        "actions": [
+          "no-op"
+        ],
+        "before": {
+          "id": "7483449866618536328",
+          "triggers": {
+            "bar": "two",
+            "foo": "one"
+          }
+        },
+        "after": {
+          "id": "7483449866618536328",
+          "triggers": {
+            "bar": "two",
+            "foo": "one"
+          }
+        },
+        "after_unknown": {},
+        "before_sensitive": {
+          "triggers": {
+            "bar": true
+          }
+        },
+        "after_sensitive": {
+          "triggers": {
+            "bar": true
+          }
+        }
+      }
+    },
+    {
+      "address": "null_resource.qux",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "qux",
+      "provider_name": "registry.terraform.io/hashicorp/null",
+      "change": {
+        "actions": [
+          "update"
+        ],
+        "before": {
+          "id": "389458145002419915",
+          "triggers": {
+            "foo": "bar"
+          }
+        },
+        "after": {
+          "id": "389458145002419915",
+          "triggers": {
+            "foo": "bar"
+          }
+        },
+        "after_unknown": {},
+        "before_sensitive": {
+          "triggers": {}
+        },
+        "after_sensitive": {
+          "triggers": {
+            "foo": true
+          }
+        }
+      }
+    }
+  ],
+  "output_changes": {
+    "secret": {
+      "actions": [
+        "no-op"
+      ],
+      "before": "7483449866618536328",
+      "after": "7483449866618536328",
+      "after_unknown": false,
+      "before_sensitive": true,
+      "after_sensitive": true
+    }
+  },
+  "prior_state": {
+    "format_version": "0.1",
+    "terraform_version": "0.15.1",
+    "values": {
+      "outputs": {
+        "secret": {
+          "sensitive": true,
+          "value": "7483449866618536328"
+        }
+      },
+      "root_module": {
+        "resources": [
+          {
+            "address": "null_resource.bar",
+            "mode": "managed",
+            "type": "null_resource",
+            "name": "bar",
+            "provider_name": "registry.terraform.io/hashicorp/null",
+            "schema_version": 0,
+            "values": {
+              "id": "4356817825751333663",
+              "triggers": {
+                "bar": "two",
+                "foo": "one"
+              }
+            }
+          },
+          {
+            "address": "null_resource.baz",
+            "mode": "managed",
+            "type": "null_resource",
+            "name": "baz",
+            "provider_name": "registry.terraform.io/hashicorp/null",
+            "schema_version": 0,
+            "values": {
+              "id": "2737458537890894185",
+              "triggers": {
+                "foo": "bar"
+              }
+            }
+          },
+          {
+            "address": "null_resource.foo",
+            "mode": "managed",
+            "type": "null_resource",
+            "name": "foo",
+            "provider_name": "registry.terraform.io/hashicorp/null",
+            "schema_version": 0,
+            "values": {
+              "id": "7483449866618536328",
+              "triggers": {
+                "bar": "two",
+                "foo": "one"
+              }
+            }
+          },
+          {
+            "address": "null_resource.qux",
+            "mode": "managed",
+            "type": "null_resource",
+            "name": "qux",
+            "provider_name": "registry.terraform.io/hashicorp/null",
+            "schema_version": 0,
+            "values": {
+              "id": "389458145002419915",
+              "triggers": {
+                "foo": "bar"
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  "configuration": {
+    "root_module": {
+      "outputs": {
+        "secret": {
+          "sensitive": true,
+          "expression": {
+            "references": [
+              "null_resource.foo"
+            ]
+          }
+        }
+      },
+      "resources": [
+        {
+          "address": "null_resource.bar",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "bar",
+          "provider_config_key": "null",
+          "expressions": {
+            "triggers": {}
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "null_resource.baz",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "baz",
+          "provider_config_key": "null",
+          "expressions": {
+            "triggers": {
+              "references": [
+                "var.foo"
+              ]
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "null_resource.foo",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "foo",
+          "provider_config_key": "null",
+          "expressions": {
+            "triggers": {}
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "null_resource.qux",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "qux",
+          "provider_config_key": "null",
+          "expressions": {
+            "triggers": {
+              "references": [
+                "var.toggle_sensitive"
+              ]
+            }
+          },
+          "schema_version": 0
+        }
+      ],
+      "variables": {
+        "foo": {
+          "default": "bar",
+          "sensitive": true
+        },
+        "toggle_sensitive": {}
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds a new package and functions for sanitization of values marked
as sensitive in the plan, where we can get particular data to do it.

This data is derived in a number of ways, also documented in the
top-level SanitizePlan function:

* ResourceChanges are sanitized based on BeforeSensitive and
AfterSensitive fields.

* Variables are sanitized based on variable config data found in the
root module of the Config.

* PlannedValues are sanitized based on the values found in
AfterSensitive in ResourceChanges. Outputs are sanitized according to
the appropriate sensitivity flags provided for the output.

* PriorState is sanitized based on the values found in BeforeSensitive
in ResourceChanges. Outputs are sanitized according to the appropriate
sensitivity flags provided for the output.

* OutputChanges are sanitized based on the values found in
BeforeSensitive and AfterSensitive. This generally means that any
sensitive output will have OutputChange fully obfuscated as the
BeforeSensitive and AfterSensitive in outputs are opaquely the same.