### PR TITLE
Added dynamic sanitization to allow for a function to be used

### DIFF
--- a/cmd/round-trip-dumper/main.go
+++ b/cmd/round-trip-dumper/main.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"os/exec"
 
-	tfjson "github.com/hashicorp/terraform-json"
+	tfjson "github.com/spacelift-io/terraform-json"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/hashicorp/terraform-json
+module github.com/spacelift-io/terraform-json
 
-go 1.13
+go 1.18
 
 require (
 	github.com/davecgh/go-spew v1.1.1
@@ -10,4 +10,9 @@ require (
 	github.com/sebdah/goldie v1.0.0
 	github.com/zclconf/go-cty v1.10.0
 	github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b
+)
+
+require (
+	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	golang.org/x/text v0.3.5 // indirect
 )

--- a/sanitize/copy.go
+++ b/sanitize/copy.go
@@ -3,8 +3,8 @@ package sanitize
 import (
 	"reflect"
 
-	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/mitchellh/copystructure"
+	tfjson "github.com/spacelift-io/terraform-json"
 )
 
 // copyStructureCopy is an internal function that wraps copystructure.Copy with

--- a/sanitize/copy_test.go
+++ b/sanitize/copy_test.go
@@ -3,7 +3,7 @@ package sanitize
 import (
 	"testing"
 
-	tfjson "github.com/hashicorp/terraform-json"
+	tfjson "github.com/spacelift-io/terraform-json"
 )
 
 func TestCopyStructureCopy(t *testing.T) {

--- a/sanitize/sanitize_change_test.go
+++ b/sanitize/sanitize_change_test.go
@@ -2,6 +2,7 @@ package sanitize
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -122,6 +123,114 @@ func changeCases() []testChangeCase {
 	}
 }
 
+func dynamicChangeCases() []testChangeCase {
+	return []testChangeCase{
+		{
+			name: "basic",
+			old: &tfjson.Change{
+				Before: map[string]interface{}{
+					"foo": map[string]interface{}{"a": "foo"},
+					"bar": map[string]interface{}{"a": "foo"},
+					"baz": map[string]interface{}{"a": "foo"},
+					"qux": map[string]interface{}{
+						"a": map[string]interface{}{
+							"b": "foo",
+						},
+						"c": "bar",
+					},
+					"quxx": map[string]interface{}{
+						"a": map[string]interface{}{
+							"b": "foo",
+						},
+						"c": "bar",
+					},
+				},
+				After: map[string]interface{}{
+					"one":   map[string]interface{}{"x": "one"},
+					"two":   map[string]interface{}{"x": "one"},
+					"three": map[string]interface{}{"x": "one"},
+					"four": map[string]interface{}{
+						"x": map[string]interface{}{
+							"y": "one",
+						},
+						"z": "two",
+					},
+					"five": map[string]interface{}{
+						"x": map[string]interface{}{
+							"y": "one",
+						},
+						"z": "two",
+					},
+				},
+				BeforeSensitive: map[string]interface{}{
+					"foo":  map[string]interface{}{},
+					"bar":  true,
+					"baz":  map[string]interface{}{"a": true},
+					"qux":  map[string]interface{}{},
+					"quxx": map[string]interface{}{"c": true},
+				},
+				AfterSensitive: map[string]interface{}{
+					"one":   map[string]interface{}{},
+					"two":   true,
+					"three": map[string]interface{}{"x": true},
+					"four":  map[string]interface{}{},
+					"five":  map[string]interface{}{"z": true},
+				},
+			},
+			expected: &tfjson.Change{
+				Before: map[string]interface{}{
+					"foo": map[string]interface{}{"a": "foo"},
+					"bar": DefaultSensitiveValue,
+					"baz": map[string]interface{}{"a": "FOO"},
+					"qux": map[string]interface{}{
+						"a": map[string]interface{}{
+							"b": "foo",
+						},
+						"c": "bar",
+					},
+					"quxx": map[string]interface{}{
+						"a": map[string]interface{}{
+							"b": "foo",
+						},
+						"c": "BAR",
+					},
+				},
+				After: map[string]interface{}{
+					"one":   map[string]interface{}{"x": "one"},
+					"two":   DefaultSensitiveValue,
+					"three": map[string]interface{}{"x": "ONE"},
+					"four": map[string]interface{}{
+						"x": map[string]interface{}{
+							"y": "one",
+						},
+						"z": "two",
+					},
+					"five": map[string]interface{}{
+						"x": map[string]interface{}{
+							"y": "one",
+						},
+						"z": "TWO",
+					},
+				},
+				BeforeSensitive: map[string]interface{}{
+					"foo":  map[string]interface{}{},
+					"bar":  true,
+					"baz":  map[string]interface{}{"a": true},
+					"qux":  map[string]interface{}{},
+					"quxx": map[string]interface{}{"c": true},
+				},
+				AfterSensitive: map[string]interface{}{
+					"one":   map[string]interface{}{},
+					"two":   true,
+					"three": map[string]interface{}{"x": true},
+					"four":  map[string]interface{}{},
+					"five":  map[string]interface{}{"z": true},
+				},
+			},
+		},
+	}
+}
+
 func TestSanitizeChange(t *testing.T) {
 	for i, tc := range changeCases() {
 		tc := tc
@@ -140,61 +249,32 @@ func TestSanitizeChange(t *testing.T) {
 			}
 		})
 	}
-
-	for i, tc := range changeCases() {
-		tc := tc
-		t.Run(fmt.Sprintf("[dynamic sanitizer] %s", tc.name), func(t *testing.T) {
-			actual, err := SanitizeChange(tc.old, DefaultSensitiveValue)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if diff := cmp.Diff(tc.expected, actual); diff != "" {
-				t.Errorf("SanitizeChange() mismatch (-expected +actual):\n%s", diff)
-			}
-
-			if diff := cmp.Diff(changeCases()[i].old, tc.old); diff != "" {
-				t.Errorf("SanitizeChange() altered original (-expected +actual):\n%s", diff)
-			}
-		})
-	}
 }
 
 func TestSanitizeChangeDynamic(t *testing.T) {
-	for i, tc := range changeCases() {
+	for i, tc := range dynamicChangeCases() {
 		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
+		t.Run(fmt.Sprintf("[dynamic replacement ToUpper] %s", tc.name), func(t *testing.T) {
 			actual, err := SanitizeChangeDynamic(tc.old, func(old interface{}) interface{} {
+				// if the data is a string we want to convert it to upper case
+				if s, ok := old.(string); ok {
+					return strings.ToUpper(s)
+				}
+				// otherwise if its not a string, we're proably looking at a map,
+				// in which case we can redact the entire item
 				return DefaultSensitiveValue
 			})
+
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			if diff := cmp.Diff(tc.expected, actual); diff != "" {
-				t.Errorf("SanitizeChange() mismatch (-expected +actual):\n%s", diff)
+				t.Errorf("SanitizeChangeDynamic() mismatch (-expected +actual):\n%s", diff)
 			}
 
-			if diff := cmp.Diff(changeCases()[i].old, tc.old); diff != "" {
-				t.Errorf("SanitizeChange() altered original (-expected +actual):\n%s", diff)
-			}
-		})
-	}
-
-	for i, tc := range changeCases() {
-		tc := tc
-		t.Run(fmt.Sprintf("[dynamic sanitizer] %s", tc.name), func(t *testing.T) {
-			actual, err := SanitizeChange(tc.old, DefaultSensitiveValue)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if diff := cmp.Diff(tc.expected, actual); diff != "" {
-				t.Errorf("SanitizeChange() mismatch (-expected +actual):\n%s", diff)
-			}
-
-			if diff := cmp.Diff(changeCases()[i].old, tc.old); diff != "" {
-				t.Errorf("SanitizeChange() altered original (-expected +actual):\n%s", diff)
+			if diff := cmp.Diff(dynamicChangeCases()[i].old, tc.old); diff != "" {
+				t.Errorf("SanitizeChangeDynamic() altered original (-expected +actual):\n%s", diff)
 			}
 		})
 	}

--- a/sanitize/sanitize_plan.go
+++ b/sanitize/sanitize_plan.go
@@ -3,7 +3,7 @@ package sanitize
 import (
 	"errors"
 
-	tfjson "github.com/hashicorp/terraform-json"
+	tfjson "github.com/spacelift-io/terraform-json"
 )
 
 const DefaultSensitiveValue = "REDACTED_SENSITIVE"
@@ -47,6 +47,37 @@ func SanitizePlan(old *tfjson.Plan) (*tfjson.Plan, error) {
 // Sensitive values are replaced with the value supplied with
 // replaceWith. A copy of the Plan is returned.
 func SanitizePlanWithValue(old *tfjson.Plan, replaceWith interface{}) (*tfjson.Plan, error) {
+	return SanitizePlanDynamic(old, NewValueSanitizer(replaceWith))
+}
+
+// SanitizePlanDynamic sanitizes the entirety of a Plan to the best
+// of its ability, depending on the provided metadata on sensitive
+// values. These are found in:
+//
+// * ResourceChanges: Sanitized based on BeforeSensitive and
+// AfterSensitive fields.
+//
+// * Variables: Based on variable config data found in the root
+// module of the Config.
+//
+// * PlannedValues: Sanitized based on the values found in
+// AfterSensitive in ResourceChanges. Outputs are sanitized
+// according to the appropriate sensitivity flags provided for the
+// output.
+//
+// * PriorState: Sanitized based on the values found in
+// BeforeSensitive in ResourceChanges. Outputs are sanitized according
+// to the appropriate sensitivity flags provided for the output.
+//
+// * OutputChanges: Sanitized based on the values found in
+// BeforeSensitive and AfterSensitive. This generally means that
+// any sensitive output will have OutputChange fully obfuscated as
+// the BeforeSensitive and AfterSensitive in outputs are opaquely the
+// same.
+//
+// Sensitive values are replaced by the Saniziter function supplied with
+// replaceWith. A copy of the Plan is returned.
+func SanitizePlanDynamic(old *tfjson.Plan, replaceWith Sanitizer) (*tfjson.Plan, error) {
 	if old == nil {
 		return nil, NilPlanError
 	}
@@ -58,20 +89,20 @@ func SanitizePlanWithValue(old *tfjson.Plan, replaceWith interface{}) (*tfjson.P
 
 	// Sanitize ResourceChanges
 	for i := range result.ResourceChanges {
-		result.ResourceChanges[i].Change, err = SanitizeChange(result.ResourceChanges[i].Change, replaceWith)
+		result.ResourceChanges[i].Change, err = SanitizeChangeDynamic(result.ResourceChanges[i].Change, replaceWith)
 		if err != nil {
 			return nil, err
 		}
 	}
 
 	// Sanitize Variables
-	result.Variables, err = SanitizePlanVariables(result.Variables, result.Config.RootModule.Variables, replaceWith)
+	result.Variables, err = SanitizePlanVariablesDynamic(result.Variables, result.Config.RootModule.Variables, replaceWith)
 	if err != nil {
 		return nil, err
 	}
 
 	// Sanitize PlannedValues
-	result.PlannedValues.RootModule, err = SanitizeStateModule(
+	result.PlannedValues.RootModule, err = SanitizeStateModuleDynamic(
 		result.PlannedValues.RootModule,
 		result.ResourceChanges,
 		SanitizeStateModuleChangeModeAfter,
@@ -80,14 +111,14 @@ func SanitizePlanWithValue(old *tfjson.Plan, replaceWith interface{}) (*tfjson.P
 		return nil, err
 	}
 
-	result.PlannedValues.Outputs, err = SanitizeStateOutputs(result.PlannedValues.Outputs, replaceWith)
+	result.PlannedValues.Outputs, err = SanitizeStateOutputsDynamic(result.PlannedValues.Outputs, replaceWith)
 	if err != nil {
 		return nil, err
 	}
 
 	// Sanitize PriorState
 	if result.PriorState != nil {
-		result.PriorState.Values.RootModule, err = SanitizeStateModule(
+		result.PriorState.Values.RootModule, err = SanitizeStateModuleDynamic(
 			result.PriorState.Values.RootModule,
 			result.ResourceChanges,
 			SanitizeStateModuleChangeModeBefore,
@@ -96,7 +127,7 @@ func SanitizePlanWithValue(old *tfjson.Plan, replaceWith interface{}) (*tfjson.P
 			return nil, err
 		}
 
-		result.PriorState.Values.Outputs, err = SanitizeStateOutputs(result.PriorState.Values.Outputs, replaceWith)
+		result.PriorState.Values.Outputs, err = SanitizeStateOutputsDynamic(result.PriorState.Values.Outputs, replaceWith)
 		if err != nil {
 			return nil, err
 		}
@@ -104,7 +135,7 @@ func SanitizePlanWithValue(old *tfjson.Plan, replaceWith interface{}) (*tfjson.P
 
 	// Sanitize OutputChanges
 	for k := range result.OutputChanges {
-		result.OutputChanges[k], err = SanitizeChange(result.OutputChanges[k], replaceWith)
+		result.OutputChanges[k], err = SanitizeChangeDynamic(result.OutputChanges[k], replaceWith)
 		if err != nil {
 			return nil, err
 		}

--- a/sanitize/sanitize_plan_test.go
+++ b/sanitize/sanitize_plan_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/sebdah/goldie"
+	tfjson "github.com/spacelift-io/terraform-json"
 )
 
 const testDataDir = "testdata"

--- a/sanitize/sanitize_plan_variables_test.go
+++ b/sanitize/sanitize_plan_variables_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	tfjson "github.com/hashicorp/terraform-json"
+	tfjson "github.com/spacelift-io/terraform-json"
 )
 
 type testVariablesCase struct {

--- a/sanitize/sanitize_plan_variables_test.go
+++ b/sanitize/sanitize_plan_variables_test.go
@@ -1,6 +1,7 @@
 package sanitize
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -46,6 +47,38 @@ func variablesCases() []testVariablesCase {
 	}
 }
 
+func dynamicVariableCases() []testVariablesCase {
+	return []testVariablesCase{
+		{
+			name: "basic",
+			old: map[string]*tfjson.PlanVariable{
+				"foo": &tfjson.PlanVariable{
+					Value: "test-foo",
+				},
+				"bar": &tfjson.PlanVariable{
+					Value: "test-bar",
+				},
+			},
+			configs: map[string]*tfjson.ConfigVariable{
+				"foo": &tfjson.ConfigVariable{
+					Sensitive: false,
+				},
+				"bar": &tfjson.ConfigVariable{
+					Sensitive: true,
+				},
+			},
+			expected: map[string]*tfjson.PlanVariable{
+				"foo": &tfjson.PlanVariable{
+					Value: "test-foo",
+				},
+				"bar": &tfjson.PlanVariable{
+					Value: "TEST-BAR",
+				},
+			},
+		},
+	}
+}
+
 func TestSanitizePlanVariables(t *testing.T) {
 	for i, tc := range variablesCases() {
 		tc := tc
@@ -61,6 +94,32 @@ func TestSanitizePlanVariables(t *testing.T) {
 
 			if diff := cmp.Diff(variablesCases()[i].old, tc.old); diff != "" {
 				t.Errorf("SanitizePlanVariables() altered original (-expected +actual):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSanitizePlanVariablesDynamic(t *testing.T) {
+	for i, tc := range dynamicVariableCases() {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := SanitizePlanVariablesDynamic(tc.old, tc.configs, func(old interface{}) interface{} {
+				// if the old value is a string, call ToUpper, else return the default redacted value
+				if s, ok := old.(string); ok {
+					return strings.ToUpper(s)
+				}
+				return DefaultSensitiveValue
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expected, actual); diff != "" {
+				t.Errorf("SanitizePlanVariablesDynamic() mismatch (-expected +actual):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(dynamicVariableCases()[i].old, tc.old); diff != "" {
+				t.Errorf("SanitizePlanVariablesDynamic() altered original (-expected +actual):\n%s", diff)
 			}
 		})
 	}

--- a/sanitize/sanitize_state_test.go
+++ b/sanitize/sanitize_state_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	tfjson "github.com/hashicorp/terraform-json"
+	tfjson "github.com/spacelift-io/terraform-json"
 	"github.com/zclconf/go-cty-debug/ctydebug"
 )
 

--- a/sanitize/sanitize_state_test.go
+++ b/sanitize/sanitize_state_test.go
@@ -1,6 +1,7 @@
 package sanitize
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -185,6 +186,175 @@ func stateCases() []testStateCase {
 	}
 }
 
+func dynamicStateCases() []testStateCase {
+	return []testStateCase{
+		{
+			name: "before",
+			old: &tfjson.StateModule{
+				Resources: []*tfjson.StateResource{
+					{
+						Address: "null_resource.foo",
+						AttributeValues: map[string]interface{}{
+							"foo": "bar",
+							"baz": "qux",
+						},
+					},
+				},
+				Address: "",
+				ChildModules: []*tfjson.StateModule{
+					&tfjson.StateModule{
+						Resources: []*tfjson.StateResource{
+							{
+								Address: "module.foo.null_resource.bar",
+								AttributeValues: map[string]interface{}{
+									"a": "b",
+									"c": "d",
+								},
+							},
+						},
+						Address:      "module.foo",
+						ChildModules: []*tfjson.StateModule{},
+					},
+				},
+			},
+			resourceChanges: []*tfjson.ResourceChange{
+				{
+					Address: "null_resource.foo",
+					Change: &tfjson.Change{
+						BeforeSensitive: map[string]interface{}{
+							"baz": true,
+						},
+						AfterSensitive: map[string]interface{}{
+							"foo": true,
+						},
+					},
+				},
+				{
+					Address: "module.foo.null_resource.bar",
+					Change: &tfjson.Change{
+						BeforeSensitive: map[string]interface{}{
+							"a": true,
+						},
+						AfterSensitive: map[string]interface{}{
+							"c": true,
+						},
+					},
+				},
+			},
+			mode: SanitizeStateModuleChangeModeBefore,
+			expected: &tfjson.StateModule{
+				Resources: []*tfjson.StateResource{
+					{
+						Address: "null_resource.foo",
+						AttributeValues: map[string]interface{}{
+							"foo": "bar",
+							"baz": "QUX",
+						},
+					},
+				},
+				Address: "",
+				ChildModules: []*tfjson.StateModule{
+					&tfjson.StateModule{
+						Resources: []*tfjson.StateResource{
+							{
+								Address: "module.foo.null_resource.bar",
+								AttributeValues: map[string]interface{}{
+									"a": "B",
+									"c": "d",
+								},
+							},
+						},
+						Address:      "module.foo",
+						ChildModules: []*tfjson.StateModule{},
+					},
+				},
+			},
+		},
+		{
+			name: "after",
+			old: &tfjson.StateModule{
+				Resources: []*tfjson.StateResource{
+					{
+						Address: "null_resource.foo",
+						AttributeValues: map[string]interface{}{
+							"foo": "bar",
+							"baz": "qux",
+						},
+					},
+				},
+				Address: "",
+				ChildModules: []*tfjson.StateModule{
+					&tfjson.StateModule{
+						Resources: []*tfjson.StateResource{
+							{
+								Address: "module.foo.null_resource.bar",
+								AttributeValues: map[string]interface{}{
+									"a": "b",
+									"c": "d",
+								},
+							},
+						},
+						Address:      "module.foo",
+						ChildModules: []*tfjson.StateModule{},
+					},
+				},
+			},
+			resourceChanges: []*tfjson.ResourceChange{
+				{
+					Address: "null_resource.foo",
+					Change: &tfjson.Change{
+						BeforeSensitive: map[string]interface{}{
+							"baz": true,
+						},
+						AfterSensitive: map[string]interface{}{
+							"foo": true,
+						},
+					},
+				},
+				{
+					Address: "module.foo.null_resource.bar",
+					Change: &tfjson.Change{
+						BeforeSensitive: map[string]interface{}{
+							"a": true,
+						},
+						AfterSensitive: map[string]interface{}{
+							"c": true,
+						},
+					},
+				},
+			},
+			mode: SanitizeStateModuleChangeModeAfter,
+			expected: &tfjson.StateModule{
+				Resources: []*tfjson.StateResource{
+					{
+						Address: "null_resource.foo",
+						AttributeValues: map[string]interface{}{
+							"foo": "BAR",
+							"baz": "qux",
+						},
+					},
+				},
+				Address: "",
+				ChildModules: []*tfjson.StateModule{
+					&tfjson.StateModule{
+						Resources: []*tfjson.StateResource{
+							{
+								Address: "module.foo.null_resource.bar",
+								AttributeValues: map[string]interface{}{
+									"a": "b",
+									"c": "D",
+								},
+							},
+						},
+						Address:      "module.foo",
+						ChildModules: []*tfjson.StateModule{},
+					},
+				},
+			},
+		},
+	}
+}
+
 func TestSanitizeStateModule(t *testing.T) {
 	for i, tc := range stateCases() {
 		tc := tc
@@ -200,6 +370,33 @@ func TestSanitizeStateModule(t *testing.T) {
 
 			if diff := cmp.Diff(stateCases()[i].old, tc.old); diff != "" {
 				t.Errorf("SanitizeStateModule() altered original (-expected +actual):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSanitizeStateModuleDynamic(t *testing.T) {
+	for i, tc := range dynamicStateCases() {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := SanitizeStateModuleDynamic(tc.old, tc.resourceChanges, tc.mode, func(old interface{}) interface{} {
+				// if the old value is a string we'll return ToUpper
+				if s, ok := old.(string); ok {
+					return strings.ToUpper(s)
+				}
+				// otherwise we'll return the default sanitization value
+				return DefaultSensitiveValue
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expected, actual); diff != "" {
+				t.Errorf("TestSanitizeStateModuleDynamic() mismatch (-expected +actual):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(dynamicStateCases()[i].old, tc.old); diff != "" {
+				t.Errorf("TestSanitizeStateModuleDynamic() altered original (-expected +actual):\n%s", diff)
 			}
 		})
 	}
@@ -237,11 +434,64 @@ func outputCases() []testOutputCase {
 	}
 }
 
+func dynamicOutputCases() []testOutputCase {
+	return []testOutputCase{
+		{
+			name: "basic",
+			old: map[string]*tfjson.StateOutput{
+				"foo": {
+					Value: "bar",
+				},
+				"a": {
+					Value:     "b",
+					Sensitive: true,
+				},
+			},
+			expected: map[string]*tfjson.StateOutput{
+				"foo": {
+					Value: "bar",
+				},
+				"a": {
+					Value:     "B",
+					Sensitive: true,
+				},
+			},
+		},
+	}
+}
+
 func TestSanitizeStateOutputs(t *testing.T) {
 	for i, tc := range outputCases() {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			actual, err := SanitizeStateOutputs(tc.old, DefaultSensitiveValue)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(tc.expected, actual, ctydebug.CmpOptions); diff != "" {
+				t.Errorf("SanitizeStateOutputs() mismatch (-expected +actual):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(outputCases()[i].old, tc.old, ctydebug.CmpOptions); diff != "" {
+				t.Errorf("SanitizeStateOutputs() altered original (-expected +actual):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSanitizeStateOutputsDynamic(t *testing.T) {
+	for i, tc := range dynamicOutputCases() {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := SanitizeStateOutputsDynamic(tc.old, func(old interface{}) interface{} {
+				// if the old value is a string we'll return ToUpper
+				if s, ok := old.(string); ok {
+					return strings.ToUpper(s)
+				}
+				// otherwise we'll return the default sanitization value
+				return DefaultSensitiveValue
+			})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/sanitize/sanitizer.go
+++ b/sanitize/sanitizer.go
@@ -1,0 +1,9 @@
+package sanitize
+
+type Sanitizer func(old interface{}) interface{}
+
+func NewValueSanitizer(value interface{}) Sanitizer {
+	return func(old interface{}) interface{} {
+		return value
+	}
+}


### PR DESCRIPTION
This facilitates the idea of applying a function to edit values in a tfPlan. This sanitization functionality can be used to hash, encrypt or otherwise sanitize data using your own methodology.

This PR also:
 - Moves to github.com/spacelift-io/terraform-json
 - Bumps golang version to 1.18