### PR TITLE
Add resource drift field to plan

### DIFF
--- a/plan.go
+++ b/plan.go
@@ -42,6 +42,10 @@ type Plan struct {
 	// this plan.
 	PlannedValues *StateValues `json:"planned_values,omitempty"`
 
+	// The change operations for resources and data sources within this plan
+	// resulting from resource drift.
+	ResourceDrift []*ResourceChange `json:"resource_drift,omitempty"`
+
 	// The change operations for resources and data sources within this
 	// plan.
 	ResourceChanges []*ResourceChange `json:"resource_changes,omitempty"`


### PR DESCRIPTION
This PR adds the `ResourceDrift` field to terraform-json. This field has been included in plan JSON representations since v0.15.2. Furthermore, this library will be utilized by tfc-agent in order to redact Terraform plans. Changes resulting from resource drift consist of one of those redaction paths. 