### PR TITLE
Update CODEOWNERS to fix syntax

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,2 @@
 # This codebase has shared ownership and responsibility.
-* @hashicorp/terraform-core
-* @hashicorp/terraform-devex
-* @hashicorp/tf-editor-experience-engineers
+* @hashicorp/terraform-core @hashicorp/terraform-devex @hashicorp/tf-editor-experience-engineers


### PR DESCRIPTION
The `CODEOWNERS` syntax assumes that co-owners are listed on the same line.

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file

The format is `path owner` and with the same path it seems to be interpreted as "last owner wins", which isn't what was intended.