### PR TITLE
SEC-090: Automated trusted workflow pinning (2023-03-10)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,9 +30,9 @@ jobs:
           - "1.20"
     steps:
       - name: Checkout
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # https://github.com/actions/checkout/releases/tag/v3.3.0
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Set up Go
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # https://github.com/actions/setup-go/releases/tag/v3.5.0
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version: ${{ matrix.go }}
       - name: Go mod download


### PR DESCRIPTION
This PR pins action references in workflow and action files to SHAs.
This is in support of [SEC-090](https://github.com/hashicorp/security-tsccr/issues/214);
Any questions please reach out to [#team-prodsec](https://go.hashi.co/team-prodsec)
