### PR TITLE
Update README to explain when not to use this library

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,13 @@ general purpose use.
 The Terraform core team **recommends against** using `terraform-json` if your
 application has any of the following requirements:
 
-* **Broad version compatibility**: each version this library represents a specific
+* **Forwards-compatibility**: each version of this library represents a specific
   snapshot of the [Terraform JSON output format](https://developer.hashicorp.com/terraform/internals/json-format),
-  and it often slightly lags Terraform itself. If you require compatibility with
-  multiple Terraform versions, we recommend implementing your own custom decoders
-  for the parts of the JSON format you need.
+  and it often slightly lags Terraform itself. The library supports
+  [the 1.x compatibility promises](https://developer.hashicorp.com/terraform/language/v1-compatibility-promises)
+  but you will need to upgrade the version promptly to use new additions. If you
+  require full compatibility with future Terraform versions, we recommend
+  implementing your own custom decoders for the parts of the JSON format you need.
 * **Writing JSON output**: the structures in this library are not guaranteed to emit
   JSON data which is semantically equivalent to Terraform itself. If your application
   must robustly write JSON data to be consumed by systems which expect Terraform's

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ general purpose use.
 The Terraform core team **recommends against** using `terraform-json` if your
 application has any of the following requirements:
 
-* **Forwards-compatibility**: each version of this library represents a specific
+* **Forward-compatibility**: each version of this library represents a specific
   snapshot of the [Terraform JSON output format](https://developer.hashicorp.com/terraform/internals/json-format),
-  and it often slightly lags Terraform itself. The library supports
+  and it often slightly lags behind Terraform itself. The library supports
   [the 1.x compatibility promises](https://developer.hashicorp.com/terraform/language/v1-compatibility-promises)
   but you will need to upgrade the version promptly to use new additions. If you
   require full compatibility with future Terraform versions, we recommend

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ application has any of the following requirements:
   ignored by earlier versions of consumers. This library **drops unknown attributes**,
   which means it is unsuitable for any application which intends to filter data
   or read-modify-write data which will be consumed downstream. Any application doing
-  this will silently drop new data from new versions. For this applicaiton, you should
+  this will silently drop new data from new versions. For this application, you should
   implement a custom decoder and encoder which preserves any unknown attributes
   through a round-trip.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,37 @@ This repository also serves as de facto documentation for the formats produced
 by these commands. For more details, see the
 [GoDoc](https://godoc.org/github.com/hashicorp/terraform-json).
 
-## Why a Separate Repository?
+## Should I use this library?
+
+This library was built for a few specific applications, and is not intended for
+general purpose use.
+
+The Terraform core team **recommends against** using `terraform-json` if your
+application has any of the following requirements:
+
+* **Broad version compatibility**: each version this library represents a specific
+  snapshot of the [Terraform JSON output format](https://developer.hashicorp.com/terraform/internals/json-format),
+  and it often slightly lags Terraform itself. If you require compatibility with
+  multiple Terraform versions, we recommend implementing your own custom decoders
+  for the parts of the JSON format you need.
+* **Writing JSON output**: the structures in this library are not guaranteed to emit
+  JSON data which is semantically equivalent to Terraform itself. If your application
+  must robustly write JSON data to be consumed by systems which expect Terraform's
+  format to be supported, you should implement your own custom encoders.
+* **Filtering or round-tripping**: the Terraform JSON formats are designed to be
+  forwards compatible, and permit new attributes to be added which may safely be
+  ignored by earlier versions of consumers. This library **drops unknown attributes**,
+  which means it is unsuitable for any application which intends to filter data
+  or read-modify-write data which will be consumed downstream. Any application doing
+  this will silently drop new data from new versions. For this applicaiton, you should
+  implement a custom decoder and encoder which preserves any unknown attributes
+  through a round-trip.
+
+When is `terraform-json` suitable? We recommend using it for applications which
+decode the core stable data types and use it directly, and don't attempt to emit
+JSON to be consumed by applications which expect the Terraform format.
+
+## Why a separate repository?
 
 To reduce dependencies on any of Terraform core's internals, we've made a design
 decision to make any helpers or libraries that work with the external JSON data


### PR DESCRIPTION
By design, the `terraform-json` library is not always suitable for every application. Its name and prominence may cause those integrating with Terraform to assume otherwise.

This commit expands the README to attempt to clarify situations where the `terraform-json` library is not appropriate, explaining why and what to do instead.