### PR TITLE
tfjson: Add `DeferredChanges` and `Complete` to `Plan` JSON

### DIFF
--- a/plan.go
+++ b/plan.go
@@ -60,6 +60,10 @@ type Plan struct {
 	// plan.
 	ResourceChanges []*ResourceChange `json:"resource_changes,omitempty"`
 
+	// DeferredChanges contains the change operations for resources that are deferred
+	// for this plan.
+	DeferredChanges []*DeferredResourceChange `json:"deferred_changes,omitempty"`
+
 	// The change operations for outputs within this plan.
 	OutputChanges map[string]*Change `json:"output_changes,omitempty"`
 
@@ -268,4 +272,14 @@ type Importing struct {
 type PlanVariable struct {
 	// The value for this variable at plan time.
 	Value interface{} `json:"value,omitempty"`
+}
+
+// DeferredResourceChange is a description of a resource change that has been
+// deferred for some reason.
+type DeferredResourceChange struct {
+	// Reason is the reason why this resource change was deferred.
+	Reason string `json:"reason,omitempty"`
+
+	// Change contains any information we have about the deferred change.
+	ResourceChange *ResourceChange `json:"resource_change,omitempty"`
 }

--- a/plan.go
+++ b/plan.go
@@ -64,6 +64,10 @@ type Plan struct {
 	// for this plan.
 	DeferredChanges []*DeferredResourceChange `json:"deferred_changes,omitempty"`
 
+	// Complete indicates that all resources have successfully planned changes.
+	// This will be false if there are DeferredChanges or if the -target flag is used.
+	Complete bool `json:"complete,omitempty"`
+
 	// The change operations for outputs within this plan.
 	OutputChanges map[string]*Change `json:"output_changes,omitempty"`
 


### PR DESCRIPTION
Ref: https://github.com/hashicorp/terraform/pull/35065

This PR adds the JSON data for deferred actions in the planfile. This data is only available when utilizing the deferred action experiment introduced in Terraform [`v1.9.0-alpha20240404`](https://github.com/hashicorp/terraform/releases/tag/v1.9.0-alpha20240404). The actual JSON output changes referenced above will be released in the upcoming alpha release.