### PR TITLE
tfjson: Update `Complete` to a pointer value for older Terraform versions

### DIFF
--- a/plan.go
+++ b/plan.go
@@ -67,9 +67,9 @@ type Plan struct {
 	// Complete indicates that all resources have successfully planned changes.
 	// This will be false if there are DeferredChanges or if the -target flag is used.
 	//
-	// Complete was introduced in Terraform 1.8 and will be false for all previous
+	// Complete was introduced in Terraform 1.8 and will be nil for all previous
 	// Terraform versions.
-	Complete bool `json:"complete,omitempty"`
+	Complete *bool `json:"complete,omitempty"`
 
 	// The change operations for outputs within this plan.
 	OutputChanges map[string]*Change `json:"output_changes,omitempty"`

--- a/plan.go
+++ b/plan.go
@@ -66,6 +66,9 @@ type Plan struct {
 
 	// Complete indicates that all resources have successfully planned changes.
 	// This will be false if there are DeferredChanges or if the -target flag is used.
+	//
+	// Complete was introduced in Terraform 1.8 and will be false for all previous
+	// Terraform versions.
 	Complete bool `json:"complete,omitempty"`
 
 	// The change operations for outputs within this plan.


### PR DESCRIPTION
Ref: https://github.com/hashicorp/terraform/pull/34642

Since [`Complete` was first present in `Terraform 1.8`](https://github.com/hashicorp/terraform/blob/v1.8.0/internal/command/jsonplan/plan.go#L67), we should make it a pointer to allow downstream tooling to determine if it was explicitly set