### PR TITLE
Add a catalog-info.yaml file for Backstage

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+#
+# Intended for internal HashiCorp use only
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: terraform-json
+  description: Helper types for the Terraform external data representation
+  annotations:
+    github.com/project-slug: hashicorp/terraform-json
+    jira/project-key: TF
+    jira/label: terraform-json
+spec:
+  type: library
+  owner: terraform-core
+  lifecycle: production


### PR DESCRIPTION
Includes basic metadata for registering `terraform-json` as a library component in our internal Backstage installation. See DW-481.