### PR TITLE
Update owner field in catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -13,5 +13,5 @@ metadata:
     jira/label: terraform-json
 spec:
   type: library
-  owner: terraform-core
+  owner: team-tf-core
   lifecycle: production


### PR DESCRIPTION
Updates the `owner` field in `catalog-info.yaml` to the team name as it exists in internal systems.

[DW-864]

[DW-864]: https://hashicorp.atlassian.net/browse/DW-864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ