### PR TITLE
logging: Add query related message types

### DIFF
--- a/logging_query.go
+++ b/logging_query.go
@@ -1,0 +1,51 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+package tfjson
+
+import "encoding/json"
+
+const (
+	MessageListStart         LogMessageType = "list_start"
+	MessageListResourceFound LogMessageType = "list_resource_found"
+	MessageListComplete      LogMessageType = "list_complete"
+)
+
+// ListStartMessage represents "query" result message of type "list_start"
+type ListStartMessage struct {
+	baseLogMessage
+	ListStart ListStartData `json:"list_start"`
+}
+
+type ListStartData struct {
+	Address      string                     `json:"address"`
+	ResourceType string                     `json:"resource_type"`
+	InputConfig  map[string]json.RawMessage `json:"input_config,omitempty"`
+}
+
+// ListResourceFoundMessage represents "query" result message of type "list_resource_found"
+type ListResourceFoundMessage struct {
+	baseLogMessage
+	ListResourceFound ListResourceFoundData `json:"list_resource_found"`
+}
+
+type ListResourceFoundData struct {
+	Address        string                     `json:"address"`
+	DisplayName    string                     `json:"display_name"`
+	Identity       map[string]json.RawMessage `json:"identity"`
+	ResourceType   string                     `json:"resource_type"`
+	ResourceObject map[string]json.RawMessage `json:"resource_object,omitempty"`
+	Config         string                     `json:"config,omitempty"`
+	ImportConfig   string                     `json:"import_config,omitempty"`
+}
+
+// ListCompleteMessage represents "query" result message of type "list_complete"
+type ListCompleteMessage struct {
+	baseLogMessage
+	ListComplete ListCompleteData `json:"list_complete"`
+}
+
+type ListCompleteData struct {
+	Address      string `json:"address"`
+	ResourceType string `json:"resource_type"`
+	Total        int    `json:"total"`
+}

--- a/logging_types.go
+++ b/logging_types.go
@@ -21,10 +21,17 @@ var allLogMessageTypes = []any{
 	LogMessage{},
 	DiagnosticLogMessage{},
 	UnknownLogMessage{},
+
+	// query
+	ListStartMessage{},
+	ListResourceFoundMessage{},
+	ListCompleteMessage{},
 }
 
 func unmarshalByType(t LogMessageType, b []byte) (LogMsg, error) {
 	switch t {
+
+	// generic
 	case MessageTypeVersion:
 		v := VersionLogMessage{}
 		return v, json.Unmarshal(b, &v)
@@ -33,6 +40,17 @@ func unmarshalByType(t LogMessageType, b []byte) (LogMsg, error) {
 		return v, json.Unmarshal(b, &v)
 	case MessageTypeDiagnostic:
 		v := DiagnosticLogMessage{}
+		return v, json.Unmarshal(b, &v)
+
+	// query
+	case MessageListStart:
+		v := ListStartMessage{}
+		return v, json.Unmarshal(b, &v)
+	case MessageListResourceFound:
+		v := ListResourceFoundMessage{}
+		return v, json.Unmarshal(b, &v)
+	case MessageListComplete:
+		v := ListCompleteMessage{}
 		return v, json.Unmarshal(b, &v)
 	}
 


### PR DESCRIPTION
## Description

This introduces types specific to the output from the planned `query` command and tests decoding against output produced by `terraform query -json` with https://registry.terraform.io/providers/dbanck/concept/latest

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
