### PR TITLE
tf query: add identity version for the list_resource_found message

### DIFF
--- a/logging_query.go
+++ b/logging_query.go
@@ -29,13 +29,14 @@ type ListResourceFoundMessage struct {
 }
 
 type ListResourceFoundData struct {
-	Address        string                     `json:"address"`
-	DisplayName    string                     `json:"display_name"`
-	Identity       map[string]json.RawMessage `json:"identity"`
-	ResourceType   string                     `json:"resource_type"`
-	ResourceObject map[string]json.RawMessage `json:"resource_object,omitempty"`
-	Config         string                     `json:"config,omitempty"`
-	ImportConfig   string                     `json:"import_config,omitempty"`
+	Address         string                     `json:"address"`
+	DisplayName     string                     `json:"display_name"`
+	Identity        map[string]json.RawMessage `json:"identity"`
+	IdentityVersion int64                      `json:"identity_version"`
+	ResourceType    string                     `json:"resource_type"`
+	ResourceObject  map[string]json.RawMessage `json:"resource_object,omitempty"`
+	Config          string                     `json:"config,omitempty"`
+	ImportConfig    string                     `json:"import_config,omitempty"`
 }
 
 // ListCompleteMessage represents "query" result message of type "list_complete"

--- a/logging_test.go
+++ b/logging_test.go
@@ -120,7 +120,7 @@ func TestLogging_query(t *testing.T) {
 			},
 		},
 		{
-			`{"@level":"info","@message":"list.concept_pet.pets: Result found","@module":"terraform.ui","@timestamp":"2025-08-28T18:07:11.534589+00:00","list_resource_found":{"address":"list.concept_pet.pets","display_name":"This is a easy-antelope","identity":{"id":"easy-antelope","legs":6},"resource_type":"concept_pet"},"type":"list_resource_found"}`,
+			`{"@level":"info","@message":"list.concept_pet.pets: Result found","@module":"terraform.ui","@timestamp":"2025-08-28T18:07:11.534589+00:00","list_resource_found":{"address":"list.concept_pet.pets","display_name":"This is a easy-antelope","identity":{"id":"easy-antelope","legs":6},"identity_version":1,"resource_type":"concept_pet"},"type":"list_resource_found"}`,
 			ListResourceFoundMessage{
 				baseLogMessage: baseLogMessage{
 					Lvl:  Info,
@@ -135,6 +135,7 @@ func TestLogging_query(t *testing.T) {
 						"id":   json.RawMessage(`"easy-antelope"`),
 						"legs": json.RawMessage("6"),
 					},
+					IdentityVersion: 1,
 				},
 			},
 		},


### PR DESCRIPTION
## Related Issue
https://github.com/hashicorp/terraform/pull/37612

## Description

This adds an the `identity_version`  field to the struct that represents the `list_resource_found` message. This hinges on a new terraform release that contains the changes in the above-mentioned related PR-

In plain English, describe your approach to addressing the issue linked above. For example, if you made a particular design decision, let us know why you chose this path instead of another solution.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
