### PR TITLE
Replace `json.RawMessage` for list log messages

### DIFF
--- a/logging_query.go
+++ b/logging_query.go
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 package tfjson
 
-import "encoding/json"
-
 const (
 	MessageListStart         LogMessageType = "list_start"
 	MessageListResourceFound LogMessageType = "list_resource_found"
@@ -17,9 +15,9 @@ type ListStartMessage struct {
 }
 
 type ListStartData struct {
-	Address      string                     `json:"address"`
-	ResourceType string                     `json:"resource_type"`
-	InputConfig  map[string]json.RawMessage `json:"input_config,omitempty"`
+	Address      string         `json:"address"`
+	ResourceType string         `json:"resource_type"`
+	InputConfig  map[string]any `json:"input_config,omitempty"`
 }
 
 // ListResourceFoundMessage represents "query" result message of type "list_resource_found"
@@ -29,14 +27,14 @@ type ListResourceFoundMessage struct {
 }
 
 type ListResourceFoundData struct {
-	Address         string                     `json:"address"`
-	DisplayName     string                     `json:"display_name"`
-	Identity        map[string]json.RawMessage `json:"identity"`
-	IdentityVersion int64                      `json:"identity_version"`
-	ResourceType    string                     `json:"resource_type"`
-	ResourceObject  map[string]json.RawMessage `json:"resource_object,omitempty"`
-	Config          string                     `json:"config,omitempty"`
-	ImportConfig    string                     `json:"import_config,omitempty"`
+	Address         string         `json:"address"`
+	DisplayName     string         `json:"display_name"`
+	Identity        map[string]any `json:"identity"`
+	IdentityVersion int64          `json:"identity_version"`
+	ResourceType    string         `json:"resource_type"`
+	ResourceObject  map[string]any `json:"resource_object,omitempty"`
+	Config          string         `json:"config,omitempty"`
+	ImportConfig    string         `json:"import_config,omitempty"`
 }
 
 // ListCompleteMessage represents "query" result message of type "list_complete"

--- a/logging_test.go
+++ b/logging_test.go
@@ -3,7 +3,6 @@
 package tfjson
 
 import (
-	"encoding/json"
 	"testing"
 	"time"
 
@@ -131,9 +130,9 @@ func TestLogging_query(t *testing.T) {
 					Address:      "list.concept_pet.pets",
 					ResourceType: "concept_pet",
 					DisplayName:  "This is a easy-antelope",
-					Identity: map[string]json.RawMessage{
-						"id":   json.RawMessage(`"easy-antelope"`),
-						"legs": json.RawMessage("6"),
+					Identity: map[string]any{
+						"id":   "easy-antelope",
+						"legs": float64(6),
 					},
 					IdentityVersion: 1,
 				},


### PR DESCRIPTION
Using an interface instead of `json.RawMessages` makes it easier to work with the log messages for downstream consumers. 

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
