### PR TITLE
Add documentation to `UnmarshalJSON` implementations

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,6 +32,10 @@ func (c *Config) Validate() error {
 	return nil
 }
 
+// UnmarshalJSON implements json.Unmarshaler for Config.
+//
+// As per established convention this method should only ever
+// be invoked *indirectly* via [encoding/json] library.
 func (c *Config) UnmarshalJSON(b []byte) error {
 	type rawConfig Config
 	var config rawConfig

--- a/expression.go
+++ b/expression.go
@@ -47,6 +47,9 @@ type ExpressionData struct {
 }
 
 // UnmarshalJSON implements json.Unmarshaler for Expression.
+//
+// As per established convention this method should only ever
+// be invoked *indirectly* via [encoding/json] library.
 func (e *Expression) UnmarshalJSON(b []byte) error {
 	result := new(ExpressionData)
 

--- a/metadata.go
+++ b/metadata.go
@@ -57,6 +57,10 @@ func (f *MetadataFunctions) Validate() error {
 	return nil
 }
 
+// UnmarshalJSON implements json.Unmarshaler for MetadataFunctions.
+//
+// As per established convention this method should only ever
+// be invoked *indirectly* via [encoding/json] library.
 func (f *MetadataFunctions) UnmarshalJSON(b []byte) error {
 	type rawFunctions MetadataFunctions
 	var functions rawFunctions

--- a/parse_test.go
+++ b/parse_test.go
@@ -18,6 +18,7 @@ const testFixtureDir = "testdata"
 const testGoldenPlanFileName = "plan.json"
 const testGoldenStateFileName = "state.json"
 const testGoldenSchemasFileName = "schemas.json"
+const testInvalidDir = "invalid"
 
 func testParse(t *testing.T, filename string, typ reflect.Type) {
 	entries, err := os.ReadDir(testFixtureDir)
@@ -31,6 +32,10 @@ func testParse(t *testing.T, filename string, typ reflect.Type) {
 		}
 
 		t.Run(e.Name(), func(t *testing.T) {
+			if e.Name() == testInvalidDir {
+				t.Skip("Skipping known invalid test fixture")
+			}
+
 			expected, err := os.ReadFile(filepath.Join(testFixtureDir, e.Name(), filename))
 			if err != nil {
 				if os.IsNotExist(err) {

--- a/plan.go
+++ b/plan.go
@@ -142,11 +142,11 @@ func (p *Plan) Validate() error {
 	return nil
 }
 
+// UnmarshalJSON implements json.Unmarshaler for Plan.
+//
+// As per established convention this method should only ever
+// be invoked *indirectly* via [encoding/json] library.
 func (p *Plan) UnmarshalJSON(b []byte) error {
-	if !json.Valid(b) {
-		return errors.New("input is not a valid JSON")
-	}
-
 	type rawPlan Plan
 	var plan rawPlan
 

--- a/plan.go
+++ b/plan.go
@@ -146,6 +146,10 @@ func (p *Plan) UnmarshalJSON(b []byte) error {
 	type rawPlan Plan
 	var plan rawPlan
 
+	if !json.Valid(b) {
+		return errors.New("invalid JSON")
+	}
+
 	dec := json.NewDecoder(bytes.NewReader(b))
 	if p.useJSONNumber {
 		dec.UseNumber()

--- a/plan.go
+++ b/plan.go
@@ -143,12 +143,12 @@ func (p *Plan) Validate() error {
 }
 
 func (p *Plan) UnmarshalJSON(b []byte) error {
+	if !json.Valid(b) {
+		return errors.New("input is not a valid JSON")
+	}
+
 	type rawPlan Plan
 	var plan rawPlan
-
-	if !json.Valid(b) {
-		return errors.New("invalid JSON")
-	}
 
 	dec := json.NewDecoder(bytes.NewReader(b))
 	if p.useJSONNumber {

--- a/plan_test.go
+++ b/plan_test.go
@@ -5,7 +5,6 @@ package tfjson
 
 import (
 	"encoding/json"
-	"errors"
 	"io"
 	"os"
 	"reflect"
@@ -210,7 +209,7 @@ func TestPlan_UnmarshalJSON(t *testing.T) {
 
 			plan.UseJSONNumber(testCase.useJSONNumber)
 
-			err = plan.UnmarshalJSON(b)
+			err = json.Unmarshal(b, &plan)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -234,12 +233,12 @@ func TestPlan_UnmarshalJSON(t *testing.T) {
 	}
 
 	jsonValidationTestCases := map[string]struct {
-		filePath      string
-		expectedError error
+		filePath    string
+		expectError bool
 	}{
 		"invalid plan JSON": {
-			filePath:      "testdata/invalid/plan.json",
-			expectedError: errors.New("input is not a valid JSON"),
+			filePath:    "testdata/invalid/plan.json",
+			expectError: true,
 		},
 		"valid plan JSON": {
 			filePath: "testdata/basic/plan.json",
@@ -260,17 +259,13 @@ func TestPlan_UnmarshalJSON(t *testing.T) {
 			}
 
 			var plan Plan
-			err = plan.UnmarshalJSON(b)
+			err = json.Unmarshal(b, &plan)
 
-			if tc.expectedError != nil {
-				if err.Error() != tc.expectedError.Error() {
-					t.Fatalf("expected error %v; got %v", tc.expectedError.Error(), err.Error())
-				} else if err == nil {
-					t.Fatalf("expected error %v; got nil", tc.expectedError)
-				}
+			if tc.expectError && err == nil {
+				t.Fatalf("expected error; got none")
 			}
 
-			if tc.expectedError == nil && err != nil {
+			if !tc.expectError && err != nil {
 				t.Errorf("expected no error, got %q", err.Error())
 			}
 		})

--- a/schemas.go
+++ b/schemas.go
@@ -60,6 +60,10 @@ func (p *ProviderSchemas) Validate() error {
 	return nil
 }
 
+// UnmarshalJSON implements json.Unmarshaler for ProviderSchemas.
+//
+// As per established convention this method should only ever
+// be invoked *indirectly* via [encoding/json] library.
 func (p *ProviderSchemas) UnmarshalJSON(b []byte) error {
 	type rawSchemas ProviderSchemas
 	var schemas rawSchemas

--- a/state.go
+++ b/state.go
@@ -82,6 +82,10 @@ func (s *State) UnmarshalJSON(b []byte) error {
 	type rawState State
 	var state rawState
 
+	if !json.Valid(b) {
+		return errors.New("invalid JSON")
+	}
+
 	dec := json.NewDecoder(bytes.NewReader(b))
 	if s.useJSONNumber {
 		dec.UseNumber()

--- a/state.go
+++ b/state.go
@@ -78,11 +78,11 @@ func (s *State) Validate() error {
 	return nil
 }
 
+// UnmarshalJSON implements json.Unmarshaler for State.
+//
+// As per established convention this method should only ever
+// be invoked *indirectly* via [encoding/json] library.
 func (s *State) UnmarshalJSON(b []byte) error {
-	if !json.Valid(b) {
-		return errors.New("input is not a valid JSON")
-	}
-
 	type rawState State
 	var state rawState
 

--- a/state.go
+++ b/state.go
@@ -79,12 +79,12 @@ func (s *State) Validate() error {
 }
 
 func (s *State) UnmarshalJSON(b []byte) error {
+	if !json.Valid(b) {
+		return errors.New("input is not a valid JSON")
+	}
+
 	type rawState State
 	var state rawState
-
-	if !json.Valid(b) {
-		return errors.New("invalid JSON")
-	}
 
 	dec := json.NewDecoder(bytes.NewReader(b))
 	if s.useJSONNumber {

--- a/state_test.go
+++ b/state_test.go
@@ -5,7 +5,6 @@ package tfjson
 
 import (
 	"encoding/json"
-	"errors"
 	"io"
 	"os"
 	"testing"
@@ -45,15 +44,15 @@ func TestStateValidate_raw(t *testing.T) {
 
 func TestStateUnmarshal(t *testing.T) {
 	testCases := map[string]struct {
-		filePath      string
-		expectedError error
+		filePath    string
+		expectError bool
 	}{
 		"valid state JSON": {
 			filePath: "testdata/no_changes/state.json",
 		},
 		"invalid state JSON": {
-			filePath:      "testdata/invalid/state.json",
-			expectedError: errors.New("input is not a valid JSON"),
+			filePath:    "testdata/invalid/state.json",
+			expectError: true,
 		},
 	}
 
@@ -71,17 +70,13 @@ func TestStateUnmarshal(t *testing.T) {
 			}
 
 			var state State
-			err = state.UnmarshalJSON(b)
+			err = json.Unmarshal(b, &state)
 
-			if tc.expectedError != nil {
-				if err.Error() != tc.expectedError.Error() {
-					t.Fatalf("expected error %v; got %v", tc.expectedError.Error(), err.Error())
-				} else if err == nil {
-					t.Fatalf("expected error %v; got nil", tc.expectedError.Error())
-				}
+			if tc.expectError && err == nil {
+				t.Fatalf("expected error; got none")
 			}
 
-			if tc.expectedError == nil && err != nil {
+			if !tc.expectError && err != nil {
 				t.Errorf("expected no error, got %q", err.Error())
 			}
 		})

--- a/testdata/invalid/plan.json
+++ b/testdata/invalid/plan.json
@@ -1,0 +1,700 @@
+{
+  "format_version": "1.1",
+  "terraform_version": "1.2.0-rc1",
+  "variables": {
+    "foo": {
+      "value": "bar"
+    },
+    "map": {
+      "value": {
+        "foo": "bar",
+        "number": 42
+      }
+    },
+    "number": {
+      "value": 42
+    }
+  },
+  "planned_values": {
+    "outputs": {
+      "foo": {
+        "sensitive": true,
+        "value": "bar",
+        "type": "string"
+      },
+      "interpolated": {
+        "sensitive": false
+      },
+      "interpolated_deep": {
+        "sensitive": false
+      },
+      "list": {
+        "sensitive": false,
+        "value": [
+          "foo",
+          "bar"
+        ],
+        "type": [
+          "tuple",
+          [
+            "string",
+            "string"
+          ]
+        ]
+      },
+      "map": {
+        "sensitive": false,
+        "value": {
+          "foo": "bar",
+          "number": 42
+        },
+        "type": [
+          "object",
+          {
+            "foo": "string",
+            "number": "number"
+          }
+        ]
+      },
+      "referenced": {
+        "sensitive": false
+      },
+      "referenced_deep": {
+        "sensitive": false
+      },
+      "string": {
+        "sensitive": false,
+        "value": "foo",
+        "type": "string"
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "null_resource.bar",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "bar",
+          "provider_name": "registry.terraform.io/hashicorp/null",
+          "schema_version": 0,
+          "sensitive_values": {
+            "triggers": {}
+          }
+        },
+        {
+          "address": "null_resource.baz[0]",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "baz",
+          "index": 0,
+          "provider_name": "registry.terraform.io/hashicorp/null",
+          "schema_version": 0,
+          "sensitive_values": {
+            "triggers": {}
+          }
+        },
+        {
+          "address": "null_resource.baz[1]",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "baz",
+          "index": 1,
+          "provider_name": "registry.terraform.io/hashicorp/null",
+          "schema_version": 0,
+          "sensitive_values": {
+            "triggers": {}
+          }
+        },
+        {
+          "address": "null_resource.baz[2]",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "baz",
+          "index": 2,
+          "provider_name": "registry.terraform.io/hashicorp/null",
+          "schema_version": 0,
+          "sensitive_values": {
+            "triggers": {}
+          }
+        },
+        {
+          "address": "null_resource.foo",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "foo",
+          "provider_name": "registry.terraform.io/hashicorp/null",
+          "schema_version": 0,
+          "values": {
+            "triggers": {
+              "foo": "bar"
+            }
+          },
+          "sensitive_values": {
+            "triggers": {}
+          }
+        }
+      ],
+      "child_modules": [
+        {
+          "resources": [
+            {
+              "address": "module.foo.null_resource.aliased",
+              "mode": "managed",
+              "type": "null_resource",
+              "name": "aliased",
+              "provider_name": "registry.terraform.io/hashicorp/null",
+              "schema_version": 0,
+              "values": {
+                "triggers": null
+              },
+              "sensitive_values": {}
+            },
+            {
+              "address": "module.foo.null_resource.foo",
+              "mode": "managed",
+              "type": "null_resource",
+              "name": "foo",
+              "provider_name": "registry.terraform.io/hashicorp/null",
+              "schema_version": 0,
+              "values": {
+                "triggers": {
+                  "foo": "bar"
+                }
+              },
+              "sensitive_values": {
+                "triggers": {}
+              }
+            }
+          ],
+          "address": "module.foo"
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "module.foo.null_resource.aliased",
+      "module_address": "module.foo",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "aliased",
+      "provider_name": "registry.terraform.io/hashicorp/null",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "triggers": null
+        },
+        "after_unknown": {
+          "id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {}
+      }
+    },
+    {
+      "address": "module.foo.null_resource.foo",
+      "module_address": "module.foo",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "foo",
+      "provider_name": "registry.terraform.io/hashicorp/null",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "triggers": {
+            "foo": "bar"
+          }
+        },
+        "after_unknown": {
+          "id": true,
+          "triggers": {}
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "triggers": {}
+        }
+      }
+    },
+    {
+      "address": "null_resource.bar",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "bar",
+      "provider_name": "registry.terraform.io/hashicorp/null",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {},
+        "after_unknown": {
+          "id": true,
+          "triggers": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "triggers": {}
+        }
+      }
+    },
+    {
+      "address": "null_resource.baz[0]",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "baz",
+      "index": 0,
+      "provider_name": "registry.terraform.io/hashicorp/null",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {},
+        "after_unknown": {
+          "id": true,
+          "triggers": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "triggers": {}
+        }
+      }
+    },
+    {
+      "address": "null_resource.baz[1]",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "baz",
+      "index": 1,
+      "provider_name": "registry.terraform.io/hashicorp/null",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {},
+        "after_unknown": {
+          "id": true,
+          "triggers": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "triggers": {}
+        }
+      }
+    },
+    {
+      "address": "null_resource.baz[2]",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "baz",
+      "index": 2,
+      "provider_name": "registry.terraform.io/hashicorp/null",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {},
+        "after_unknown": {
+          "id": true,
+          "triggers": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "triggers": {}
+        }
+      }
+    },
+    {
+      "address": "null_resource.foo",
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "foo",
+      "provider_name": "registry.terraform.io/hashicorp/null",
+      "change": {
+        "actions": [
+          "create"
+        ],
+        "before": null,
+        "after": {
+          "triggers": {
+            "foo": "bar"
+          }
+        },
+        "after_unknown": {
+          "id": true,
+          "triggers": {}
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "triggers": {}
+        }
+      }
+    }
+  ],
+  "output_changes": {
+    "foo": {
+      "actions": [
+        "create"
+      ],
+      "before": null,
+      "after": "bar",
+      "after_unknown": false,
+      "before_sensitive": true,
+      "after_sensitive": true
+    },
+    "interpolated": {
+      "actions": [
+        "create"
+      ],
+      "before": null,
+      "after_unknown": true,
+      "before_sensitive": false,
+      "after_sensitive": false
+    },
+    "interpolated_deep": {
+      "actions": [
+        "create"
+      ],
+      "before": null,
+      "after_unknown": true,
+      "before_sensitive": false,
+      "after_sensitive": false
+    },
+    "list": {
+      "actions": [
+        "create"
+      ],
+      "before": null,
+      "after": [
+        "foo",
+        "bar"
+      ],
+      "after_unknown": false,
+      "before_sensitive": false,
+      "after_sensitive": false
+    },
+    "map": {
+      "actions": [
+        "create"
+      ],
+      "before": null,
+      "after": {
+        "foo": "bar",
+        "number": 42
+      },
+      "after_unknown": false,
+      "before_sensitive": false,
+      "after_sensitive": false
+    },
+    "referenced": {
+      "actions": [
+        "create"
+      ],
+      "before": null,
+      "after_unknown": true,
+      "before_sensitive": false,
+      "after_sensitive": false
+    },
+    "referenced_deep": {
+      "actions": [
+        "create"
+      ],
+      "before": null,
+      "after_unknown": true,
+      "before_sensitive": false,
+      "after_sensitive": false
+    },
+    "string": {
+      "actions": [
+        "create"
+      ],
+      "before": null,
+      "after": "foo",
+      "after_unknown": false,
+      "before_sensitive": false,
+      "after_sensitive": false
+    }
+  },
+  "prior_state": {
+    "format_version": "1.0",
+    "terraform_version": "1.2.0",
+    "values": {
+      "outputs": {
+        "foo": {
+          "sensitive": true,
+          "value": "bar",
+          "type": "string"
+        },
+        "list": {
+          "sensitive": false,
+          "value": [
+            "foo",
+            "bar"
+          ],
+          "type": [
+            "tuple",
+            [
+              "string",
+              "string"
+            ]
+          ]
+        },
+        "map": {
+          "sensitive": false,
+          "value": {
+            "foo": "bar",
+            "number": 42
+          },
+          "type": [
+            "object",
+            {
+              "foo": "string",
+              "number": "number"
+            }
+          ]
+        },
+        "string": {
+          "sensitive": false,
+          "value": "foo",
+          "type": "string"
+        }
+      },
+      "root_module": {}
+    }
+  },
+  "configuration": {
+    "provider_config": {
+      "aws": {
+        "name": "aws",
+        "full_name": "registry.terraform.io/hashicorp/aws",
+        "expressions": {
+          "region": {
+            "constant_value": "us-west-2"
+          }
+        }
+      },
+      "aws.east": {
+        "name": "aws",
+        "full_name": "registry.terraform.io/hashicorp/aws",
+        "alias": "east",
+        "expressions": {
+          "region": {
+            "constant_value": "us-east-1"
+          }
+        }
+      },
+      "null": {
+        "name": "null",
+        "full_name": "registry.terraform.io/hashicorp/null"
+      }
+    },
+    "root_module": {
+      "outputs": {
+        "foo": {
+          "sensitive": true,
+          "expression": {
+            "constant_value": "bar"
+          }
+        },
+        "interpolated": {
+          "expression": {
+            "references": [
+              "null_resource.foo.id",
+              "null_resource.foo"
+            ]
+          }
+        },
+        "interpolated_deep": {
+          "expression": {
+            "references": [
+              "null_resource.foo.id",
+              "null_resource.foo"
+            ]
+          }
+        },
+        "list": {
+          "expression": {
+            "constant_value": [
+              "foo",
+              "bar"
+            ]
+          }
+        },
+        "map": {
+          "expression": {
+            "constant_value": {
+              "foo": "bar",
+              "number": 42
+            }
+          }
+        },
+        "referenced": {
+          "expression": {
+            "references": [
+              "null_resource.foo.id",
+              "null_resource.foo"
+            ]
+          }
+        },
+        "referenced_deep": {
+          "expression": {
+            "references": [
+              "null_resource.foo.id",
+              "null_resource.foo"
+            ]
+          }
+        },
+        "string": {
+          "expression": {
+            "constant_value": "foo"
+          }
+        }
+      },
+      "resources": [
+        {
+          "address": "null_resource.bar",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "bar",
+          "provider_config_key": "null",
+          "expressions": {
+            "triggers": {
+              "references": [
+                "null_resource.foo.id",
+                "null_resource.foo"
+              ]
+            }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "null_resource.baz",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "baz",
+          "provider_config_key": "null",
+          "expressions": {
+            "triggers": {
+              "references": [
+                "null_resource.foo.id",
+                "null_resource.foo"
+              ]
+            }
+          },
+          "schema_version": 0,
+          "count_expression": {
+            "constant_value": 3
+          }
+        },
+        {
+          "address": "null_resource.foo",
+          "mode": "managed",
+          "type": "null_resource",
+          "name": "foo",
+          "provider_config_key": "null",
+          "provisioners": [
+            {
+              "type": "local-exec",
+              "expressions": {
+                "command": {
+                  "constant_value": "echo hello"
+                }
+              }
+            }
+          ],
+          "expressions": {
+            "triggers": {
+              "constant_value": {
+                "foo": "bar"
+              }
+            }
+          },
+          "schema_version": 0
+        }
+      ],
+      "module_calls": {
+        "foo": {
+          "source": "./foo",
+          "expressions": {
+            "bar": {
+              "constant_value": "baz"
+            },
+            "one": {
+              "constant_value": "two"
+            }
+          },
+          "module": {
+            "outputs": {
+              "foo": {
+                "expression": {
+                  "constant_value": "bar"
+                }
+              }
+            },
+            "resources": [
+              {
+                "address": "null_resource.aliased",
+                "mode": "managed",
+                "type": "null_resource",
+                "name": "aliased",
+                "provider_config_key": "null",
+                "schema_version": 0
+              },
+              {
+                "address": "null_resource.foo",
+                "mode": "managed",
+                "type": "null_resource",
+                "name": "foo",
+                "provider_config_key": "null",
+                "expressions": {
+                  "triggers": {
+                    "constant_value": {
+                      "foo": "bar"
+                    }
+                  }
+                },
+                "schema_version": 0
+              }
+            ],
+            "variables": {
+              "bar": {},
+              "one": {}
+            }
+          }
+        }
+      },
+      "variables": {
+        "foo": {
+          "default": {}}}}}}},
+          "description": "foobar",
+          "sensitive": true,
+        },
+        "map": {
+          "default": {
+            "foo": "bar",
+            "number": 42
+          }
+        },
+        "number": {
+          "default": 42
+        }
+      }
+    }
+  },
+  "relevant_attributes": [
+    {
+      "resource": "null_resource.foo",
+      "attribute": [
+        "id"
+      ]
+    }
+  ]
+}

--- a/testdata/invalid/state.json
+++ b/testdata/invalid/state.json
@@ -1,0 +1,17 @@
+{
+  "format_version" : "1.2",
+  "terraform_version": "1.5.0",
+  "variables": {
+    "my-secret": {
+      "value": "PASSWORD123"
+    }
+  },
+  "configuration": {
+    "root_module": {
+      "variables": {
+        "my-secret": {}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}}},
+        "sensitive": true
+      }
+    }
+  }
+}

--- a/validate.go
+++ b/validate.go
@@ -137,6 +137,10 @@ func (vo *ValidateOutput) Validate() error {
 	return nil
 }
 
+// UnmarshalJSON implements json.Unmarshaler for ValidateOutput.
+//
+// As per established convention this method should only ever
+// be invoked *indirectly* via [encoding/json] library.
 func (vo *ValidateOutput) UnmarshalJSON(b []byte) error {
 	type rawOutput ValidateOutput
 	var schemas rawOutput


### PR DESCRIPTION
## Related Issue

Fixes https://hashicorp.atlassian.net/browse/SECVULN-24144

## Description

Use JSON validation from [Go's JSON parser](https://pkg.go.dev/encoding/json#pkg-overview) to reject malformed JSON inputs in `State` and `Plan` structs.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? No.
