### PR TITLE
validate: add `Diagnostic.Address`

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -44,6 +44,7 @@ const (
 type Diagnostic struct {
 	Severity DiagnosticSeverity `json:"severity,omitempty"`
 
+	Address string `json:"address,omitempty"`
 	Summary string `json:"summary,omitempty"`
 	Detail  string `json:"detail,omitempty"`
 	Range   *Range `json:"range,omitempty"`

--- a/validate_test.go
+++ b/validate_test.go
@@ -70,7 +70,12 @@ func TestValidateOutput_basic(t *testing.T) {
           "byte": 200
         }
       }
-    }
+    },
+	{
+		"severity": "warning",
+		"summary": "no ice cream",
+		"address": "module.icebox.ice_cream.vanilla"
+	}
   ]
 }`
 	var parsed ValidateOutput
@@ -103,6 +108,11 @@ func TestValidateOutput_basic(t *testing.T) {
 						Byte:   200,
 					},
 				},
+			},
+			{
+				Severity: "warning",
+				Address:  "module.icebox.ice_cream.vanilla",
+				Summary:  "no ice cream",
 			},
 		},
 	}


### PR DESCRIPTION
## Description

This change maps `Diagnostic.Address` from `terraform validate -json` to a Go struct field.  

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None.