### PR TITLE
version: Allow parsing of a format_version field, added in v1.17

### DIFF
--- a/version.go
+++ b/version.go
@@ -6,6 +6,8 @@ package tfjson
 // VersionOutput represents output from the version -json command
 // added in v0.13
 type VersionOutput struct {
+	FormatVersion string `json:"format_version"` // Added in v1.17
+
 	Version            string            `json:"terraform_version"`
 	Revision           string            `json:"terraform_revision"`
 	Platform           string            `json:"platform,omitempty"`

--- a/version_test.go
+++ b/version_test.go
@@ -67,3 +67,35 @@ func TestVersionOutput_015(t *testing.T) {
 		t.Fatalf("output mismatch: %s", diff)
 	}
 }
+
+// In TF v1.17 we added the format_version field,
+// to match how other static JSON outputs are versioned.
+func TestVersionOutput_117(t *testing.T) {
+	output := `{
+  "format_version": "1.0",
+  "terraform_version": "4.5.6-foo",
+  "platform": "aros_riscv64",
+  "provider_selections": {
+    "registry.terraform.io/hashicorp/test1": "7.8.9-beta.2",
+    "registry.terraform.io/hashicorp/test2": "1.2.3"
+  },
+  "terraform_outdated": false
+}`
+	var parsed VersionOutput
+	if err := json.Unmarshal([]byte(output), &parsed); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := &VersionOutput{
+		FormatVersion: "1.0",
+		Version:       "4.5.6-foo",
+		Platform:      "aros_riscv64",
+		ProviderSelections: map[string]string{
+			"registry.terraform.io/hashicorp/test1": "7.8.9-beta.2",
+			"registry.terraform.io/hashicorp/test2": "1.2.3",
+		},
+	}
+	if diff := cmp.Diff(expected, &parsed); diff != "" {
+		t.Fatalf("output mismatch: %s", diff)
+	}
+}


### PR DESCRIPTION
## Related Issue

References: https://github.com/hashicorp/terraform/pull/38930

## Description

Allows the new format_version field in the version command's JSON output to be parsed.
The existing tests show that lacking the field is tolerated when unmarshalling into the struct with the new field.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

N/A